### PR TITLE
Bump euclid dependency to 0.14.1.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plane-split"
-version = "0.4.1"
+version = "0.5.0"
 description = "Plane splitting"
 authors = ["Dzmitry Malyshau <kvark@mozilla.com>"]
 license = "MPL-2.0"
@@ -10,6 +10,6 @@ documentation = "https://docs.rs/plane-split"
 
 [dependencies]
 binary-space-partition = "0.1.2"
-euclid = "0.13"
+euclid = "0.14.2"
 log = "0.3"
 num-traits = {version = "0.1.37", default-features = false}

--- a/benches/split.rs
+++ b/benches/split.rs
@@ -5,14 +5,14 @@ extern crate plane_split;
 extern crate test;
 
 use std::sync::Arc;
-use euclid::TypedPoint3D;
+use euclid::vec3;
 use plane_split::{BspSplitter, NaiveSplitter, Splitter, _make_grid};
 
 #[bench]
 fn bench_naive(b: &mut test::Bencher) {
     let polys = Arc::new(_make_grid(5));
     let mut splitter = NaiveSplitter::new();
-    let view = TypedPoint3D::new(0.0, 0.0, 1.0);
+    let view = vec3(0.0, 0.0, 1.0);
     b.iter(|| {
         let p = polys.clone();
         splitter.solve(&p, view);
@@ -23,7 +23,7 @@ fn bench_naive(b: &mut test::Bencher) {
 fn bench_bsp(b: &mut test::Bencher) {
     let polys = Arc::new(_make_grid(5));
     let mut splitter = BspSplitter::new();
-    let view = TypedPoint3D::new(0.0, 0.0, 1.0);
+    let view = vec3(0.0, 0.0, 1.0);
     b.iter(|| {
         let p = polys.clone();
         splitter.solve(&p, view);

--- a/src/bsp.rs
+++ b/src/bsp.rs
@@ -1,5 +1,5 @@
 use binary_space_partition::{BspNode, Plane, PlaneCut};
-use euclid::TypedPoint3D;
+use euclid::{TypedPoint3D, TypedVector3D};
 use euclid::approxeq::ApproxEq;
 use num_traits::{Float, One, Zero};
 use std::{fmt, ops};
@@ -96,10 +96,10 @@ impl<T, U> Splitter<T, U> for BspSplitter<T, U> where
         self.tree.insert(poly);
     }
 
-    fn sort(&mut self, view: TypedPoint3D<T, U>) -> &[Polygon<T, U>] {
+    fn sort(&mut self, view: TypedVector3D<T, U>) -> &[Polygon<T, U>] {
         //debug!("\t\ttree before sorting {:?}", self.tree);
         let poly = Polygon {
-            points: [TypedPoint3D::zero(); 4],
+            points: [TypedPoint3D::origin(); 4],
             normal: -view, //Note: BSP `order()` is back to front
             offset: T::zero(),
             anchor: 0,

--- a/src/naive.rs
+++ b/src/naive.rs
@@ -1,7 +1,7 @@
 use std::{fmt, ops};
 use std::cmp::Ordering;
 use {Intersection, Line, Polygon, Splitter};
-use euclid::TypedPoint3D;
+use euclid::TypedVector3D;
 use euclid::approxeq::ApproxEq;
 use num_traits::{Float, One, Zero};
 
@@ -27,8 +27,8 @@ impl<T, U> NaiveSplitter<T, U> {
 /// Find a closest intersection point between two polygons,
 /// across the specified direction.
 fn intersect_across<T, U>(a: &Polygon<T, U>, b: &Polygon<T, U>,
-                          dir: TypedPoint3D<T, U>)
-                          -> TypedPoint3D<T, U>
+                          dir: TypedVector3D<T, U>)
+                          -> TypedVector3D<T, U>
 where
     T: Copy + fmt::Debug + PartialOrd + ApproxEq<T> +
         ops::Sub<T, Output=T> + ops::Add<T, Output=T> +
@@ -136,11 +136,11 @@ impl<
     }
 
     //TODO: verify/prove that the sorting approach is consistent
-    fn sort(&mut self, view: TypedPoint3D<T, U>) -> &[Polygon<T, U>] {
+    fn sort(&mut self, view: TypedVector3D<T, U>) -> &[Polygon<T, U>] {
         // choose the most perpendicular axis among these two
         let axis_pre = {
-            let axis_pre0 = TypedPoint3D::new(T::one(), T::zero(), T::zero());
-            let axis_pre1 = TypedPoint3D::new(T::zero(), T::one(), T::zero());
+            let axis_pre0 = TypedVector3D::new(T::one(), T::zero(), T::zero());
+            let axis_pre1 = TypedVector3D::new(T::zero(), T::one(), T::zero());
             if view.dot(axis_pre0).abs() < view.dot(axis_pre1).abs() {
                 axis_pre0
             } else {
@@ -160,7 +160,7 @@ impl<
             let comp_y = intersect_across(a, b, axis_y);
             // line that tries to intersect both
             let line = Line {
-                origin: comp_x + comp_y,
+                origin: (comp_x + comp_y).to_point(),
                 dir: view,
             };
             debug!("\t\tGot {:?}", line);

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -1,7 +1,7 @@
 extern crate euclid;
 extern crate plane_split;
 
-use euclid::{Point2D, Radians, TypedPoint2D, TypedPoint3D, TypedRect, TypedSize2D, TypedMatrix4D};
+use euclid::{Radians, TypedRect, TypedSize2D, TypedTransform3D, point2, point3, vec3};
 use euclid::approxeq::ApproxEq;
 use plane_split::{Intersection, Line, LineProjection, Polygon};
 
@@ -16,36 +16,36 @@ fn line_proj_bounds() {
 fn valid() {
     let poly_a: Polygon<f32, ()> = Polygon {
         points: [
-            TypedPoint3D::new(0.0, 0.0, 0.0),
-            TypedPoint3D::new(1.0, 1.0, 1.0),
-            TypedPoint3D::new(1.0, 1.0, 0.0),
-            TypedPoint3D::new(0.0, 1.0, 1.0),
+            point3(0.0, 0.0, 0.0),
+            point3(1.0, 1.0, 1.0),
+            point3(1.0, 1.0, 0.0),
+            point3(0.0, 1.0, 1.0),
         ],
-        normal: TypedPoint3D::new(0.0, 1.0, 0.0),
+        normal: vec3(0.0, 1.0, 0.0),
         offset: -1.0,
         anchor: 0,
     };
     assert!(!poly_a.is_valid()); // points[0] is outside
     let poly_b: Polygon<f32, ()> = Polygon {
         points: [
-            TypedPoint3D::new(0.0, 1.0, 0.0),
-            TypedPoint3D::new(1.0, 1.0, 1.0),
-            TypedPoint3D::new(1.0, 1.0, 0.0),
-            TypedPoint3D::new(0.0, 1.0, 1.0),
+            point3(0.0, 1.0, 0.0),
+            point3(1.0, 1.0, 1.0),
+            point3(1.0, 1.0, 0.0),
+            point3(0.0, 1.0, 1.0),
         ],
-        normal: TypedPoint3D::new(0.0, 1.0, 0.0),
+        normal: vec3(0.0, 1.0, 0.0),
         offset: -1.0,
         anchor: 0,
     };
     assert!(!poly_b.is_valid()); // winding is incorrect
     let poly_c: Polygon<f32, ()> = Polygon {
         points: [
-            TypedPoint3D::new(0.0, 0.0, 1.0),
-            TypedPoint3D::new(1.0, 0.0, 1.0),
-            TypedPoint3D::new(1.0, 1.0, 1.0),
-            TypedPoint3D::new(0.0, 1.0, 1.0),
+            point3(0.0, 0.0, 1.0),
+            point3(1.0, 0.0, 1.0),
+            point3(1.0, 1.0, 1.0),
+            point3(0.0, 1.0, 1.0),
         ],
-        normal: TypedPoint3D::new(0.0, 0.0, 1.0),
+        normal: vec3(0.0, 0.0, 1.0),
         offset: -1.0,
         anchor: 0,
     };
@@ -54,10 +54,10 @@ fn valid() {
 
 #[test]
 fn from_transformed_rect() {
-    let rect: TypedRect<f32, ()> = TypedRect::new(TypedPoint2D::new(10.0, 10.0), TypedSize2D::new(20.0, 30.0));
-    let transform: TypedMatrix4D<f32, (), ()> =
-        TypedMatrix4D::create_rotation(0.5f32.sqrt(), 0.0, 0.5f32.sqrt(), Radians::new(5.0))
-        .pre_translated(0.0, 0.0, 10.0);
+    let rect: TypedRect<f32, ()> = TypedRect::new(point2(10.0, 10.0), TypedSize2D::new(20.0, 30.0));
+    let transform: TypedTransform3D<f32, (), ()> =
+        TypedTransform3D::create_rotation(0.5f32.sqrt(), 0.0, 0.5f32.sqrt(), Radians::new(5.0))
+        .pre_translate(vec3(0.0, 0.0, 10.0));
     let poly = Polygon::from_transformed_rect(rect, transform, 0);
     assert!(poly.is_valid());
 }
@@ -66,45 +66,45 @@ fn from_transformed_rect() {
 fn untransform_point() {
     let poly: Polygon<f32, ()> = Polygon {
         points: [
-            TypedPoint3D::new(0.0, 0.0, 0.0),
-            TypedPoint3D::new(0.5, 1.0, 0.0),
-            TypedPoint3D::new(1.5, 1.0, 0.0),
-            TypedPoint3D::new(1.0, 0.0, 0.0),
+            point3(0.0, 0.0, 0.0),
+            point3(0.5, 1.0, 0.0),
+            point3(1.5, 1.0, 0.0),
+            point3(1.0, 0.0, 0.0),
         ],
-        normal: TypedPoint3D::new(0.0, 1.0, 0.0),
+        normal: vec3(0.0, 1.0, 0.0),
         offset: 0.0,
         anchor: 0,
     };
-    assert_eq!(poly.untransform_point(poly.points[0]), Point2D::new(0.0, 0.0));
-    assert_eq!(poly.untransform_point(poly.points[1]), Point2D::new(1.0, 0.0));
-    assert_eq!(poly.untransform_point(poly.points[2]), Point2D::new(1.0, 1.0));
-    assert_eq!(poly.untransform_point(poly.points[3]), Point2D::new(0.0, 1.0));
+    assert_eq!(poly.untransform_point(poly.points[0]), point2(0.0, 0.0));
+    assert_eq!(poly.untransform_point(poly.points[1]), point2(1.0, 0.0));
+    assert_eq!(poly.untransform_point(poly.points[2]), point2(1.0, 1.0));
+    assert_eq!(poly.untransform_point(poly.points[3]), point2(0.0, 1.0));
 }
 
 #[test]
 fn are_outside() {
     let poly: Polygon<f32, ()> = Polygon {
         points: [
-            TypedPoint3D::new(0.0, 0.0, 1.0),
-            TypedPoint3D::new(1.0, 0.0, 1.0),
-            TypedPoint3D::new(1.0, 1.0, 1.0),
-            TypedPoint3D::new(0.0, 1.0, 1.0),
+            point3(0.0, 0.0, 1.0),
+            point3(1.0, 0.0, 1.0),
+            point3(1.0, 1.0, 1.0),
+            point3(0.0, 1.0, 1.0),
         ],
-        normal: TypedPoint3D::new(0.0, 0.0, 1.0),
+        normal: vec3(0.0, 0.0, 1.0),
         offset: -1.0,
         anchor: 0,
     };
     assert!(poly.is_valid());
     assert!(poly.are_outside(&[
-        TypedPoint3D::new(0.0, 0.0, 1.1),
-        TypedPoint3D::new(1.0, 1.0, 2.0),
+        point3(0.0, 0.0, 1.1),
+        point3(1.0, 1.0, 2.0),
     ]));
     assert!(poly.are_outside(&[
-        TypedPoint3D::new(0.5, 0.5, 1.0),
+        point3(0.5, 0.5, 1.0),
     ]));
     assert!(!poly.are_outside(&[
-        TypedPoint3D::new(0.0, 0.0, 1.0),
-        TypedPoint3D::new(0.0, 0.0, -1.0),
+        point3(0.0, 0.0, 1.0),
+        point3(0.0, 0.0, -1.0),
     ]));
 }
 
@@ -112,24 +112,24 @@ fn are_outside() {
 fn intersect() {
     let poly_a: Polygon<f32, ()> = Polygon {
         points: [
-            TypedPoint3D::new(0.0, 0.0, 1.0),
-            TypedPoint3D::new(1.0, 0.0, 1.0),
-            TypedPoint3D::new(1.0, 1.0, 1.0),
-            TypedPoint3D::new(0.0, 1.0, 1.0),
+            point3(0.0, 0.0, 1.0),
+            point3(1.0, 0.0, 1.0),
+            point3(1.0, 1.0, 1.0),
+            point3(0.0, 1.0, 1.0),
         ],
-        normal: TypedPoint3D::new(0.0, 0.0, 1.0),
+        normal: vec3(0.0, 0.0, 1.0),
         offset: -1.0,
         anchor: 0,
     };
     assert!(poly_a.is_valid());
     let poly_b: Polygon<f32, ()> = Polygon {
         points: [
-            TypedPoint3D::new(0.5, 0.0, 2.0),
-            TypedPoint3D::new(0.5, 1.0, 2.0),
-            TypedPoint3D::new(0.5, 1.0, 0.0),
-            TypedPoint3D::new(0.5, 0.0, 0.0),
+            point3(0.5, 0.0, 2.0),
+            point3(0.5, 1.0, 2.0),
+            point3(0.5, 1.0, 0.0),
+            point3(0.5, 0.0, 0.0),
         ],
-        normal: TypedPoint3D::new(1.0, 0.0, 0.0),
+        normal: vec3(1.0, 0.0, 0.0),
         offset: -0.5,
         anchor: 0,
     };
@@ -149,24 +149,24 @@ fn intersect() {
 
     let poly_c: Polygon<f32, ()> = Polygon {
         points: [
-            TypedPoint3D::new(0.0, -1.0, 2.0),
-            TypedPoint3D::new(0.0, -1.0, 0.0),
-            TypedPoint3D::new(0.0, 0.0, 0.0),
-            TypedPoint3D::new(0.0, 0.0, 2.0),
+            point3(0.0, -1.0, 2.0),
+            point3(0.0, -1.0, 0.0),
+            point3(0.0, 0.0, 0.0),
+            point3(0.0, 0.0, 2.0),
         ],
-        normal: TypedPoint3D::new(1.0, 0.0, 0.0),
+        normal: vec3(1.0, 0.0, 0.0),
         offset: 0.0,
         anchor: 0,
     };
     assert!(poly_c.is_valid());
     let poly_d: Polygon<f32, ()> = Polygon {
         points: [
-            TypedPoint3D::new(0.0, 0.0, 0.5),
-            TypedPoint3D::new(1.0, 0.0, 0.5),
-            TypedPoint3D::new(1.0, 1.0, 0.5),
-            TypedPoint3D::new(0.0, 1.0, 0.5),
+            point3(0.0, 0.0, 0.5),
+            point3(1.0, 0.0, 0.5),
+            point3(1.0, 1.0, 0.5),
+            point3(0.0, 1.0, 0.5),
         ],
-        normal: TypedPoint3D::new(0.0, 0.0, 1.0),
+        normal: vec3(0.0, 0.0, 1.0),
         offset: -0.5,
         anchor: 0,
     };
@@ -195,43 +195,43 @@ fn test_cut(poly_base: &Polygon<f32, ()>, extra_count: u8, line: Line<f32, ()>) 
 fn split() {
     let poly: Polygon<f32, ()> = Polygon {
         points: [
-            TypedPoint3D::new(0.0, 1.0, 0.0),
-            TypedPoint3D::new(1.0, 1.0, 0.0),
-            TypedPoint3D::new(1.0, 1.0, 1.0),
-            TypedPoint3D::new(0.0, 1.0, 1.0),
+            point3(0.0, 1.0, 0.0),
+            point3(1.0, 1.0, 0.0),
+            point3(1.0, 1.0, 1.0),
+            point3(0.0, 1.0, 1.0),
         ],
-        normal: TypedPoint3D::new(0.0, 1.0, 0.0),
+        normal: vec3(0.0, 1.0, 0.0),
         offset: -1.0,
         anchor: 0,
     };
 
     // non-intersecting line
     test_cut(&poly, 0, Line {
-        origin: TypedPoint3D::new(0.0, 1.0, 0.5),
-        dir: TypedPoint3D::new(0.0, 1.0, 0.0),
+        origin: point3(0.0, 1.0, 0.5),
+        dir: vec3(0.0, 1.0, 0.0),
     });
 
     // simple cut (diff=2)
     test_cut(&poly, 1, Line {
-        origin: TypedPoint3D::new(0.0, 1.0, 0.5),
-        dir: TypedPoint3D::new(1.0, 0.0, 0.0),
+        origin: point3(0.0, 1.0, 0.5),
+        dir: vec3(1.0, 0.0, 0.0),
     });
 
     // complex cut (diff=1, wrapped)
     test_cut(&poly, 2, Line {
-        origin: TypedPoint3D::new(0.0, 1.0, 0.5),
-        dir: TypedPoint3D::new(0.5f32.sqrt(), 0.0, -0.5f32.sqrt()),
+        origin: point3(0.0, 1.0, 0.5),
+        dir: vec3(0.5f32.sqrt(), 0.0, -0.5f32.sqrt()),
     });
 
     // complex cut (diff=1, non-wrapped)
     test_cut(&poly, 2, Line {
-        origin: TypedPoint3D::new(0.5, 1.0, 0.0),
-        dir: TypedPoint3D::new(0.5f32.sqrt(), 0.0, 0.5f32.sqrt()),
+        origin: point3(0.5, 1.0, 0.0),
+        dir: vec3(0.5f32.sqrt(), 0.0, 0.5f32.sqrt()),
     });
 
     // complex cut (diff=3)
     test_cut(&poly, 2, Line {
-        origin: TypedPoint3D::new(0.5, 1.0, 0.0),
-        dir: TypedPoint3D::new(-0.5f32.sqrt(), 0.0, 0.5f32.sqrt()),
+        origin: point3(0.5, 1.0, 0.0),
+        dir: vec3(-0.5f32.sqrt(), 0.0, 0.5f32.sqrt()),
     });
 }

--- a/tests/split.rs
+++ b/tests/split.rs
@@ -2,13 +2,13 @@ extern crate euclid;
 extern crate plane_split;
 
 use std::f32::consts::FRAC_PI_4;
-use euclid::{Radians, TypedMatrix4D, TypedPoint2D, TypedPoint3D, TypedSize2D, TypedRect};
+use euclid::{Radians, TypedTransform3D, TypedRect, vec3};
 use plane_split::{BspSplitter, NaiveSplitter, Polygon, Splitter, _make_grid};
 
 
 fn grid_impl(count: usize, splitter: &mut Splitter<f32, ()>) {
     let polys = _make_grid(count);
-    let result = splitter.solve(&polys, TypedPoint3D::new(0.0, 0.0, 1.0));
+    let result = splitter.solve(&polys, vec3(0.0, 0.0, 1.0));
     assert_eq!(result.len(), count + count*count + count*count*count);
 }
 
@@ -24,21 +24,21 @@ fn grid_bsp() {
 
 
 fn sort_rotation(splitter: &mut Splitter<f32, ()>) {
-    let transform0: TypedMatrix4D<f32, (), ()> =
-        TypedMatrix4D::create_rotation(0.0, 1.0, 0.0, Radians::new(-FRAC_PI_4));
-    let transform1: TypedMatrix4D<f32, (), ()> =
-        TypedMatrix4D::create_rotation(0.0, 1.0, 0.0, Radians::new(0.0));
-    let transform2: TypedMatrix4D<f32, (), ()> =
-        TypedMatrix4D::create_rotation(0.0, 1.0, 0.0, Radians::new(FRAC_PI_4));
+    let transform0: TypedTransform3D<f32, (), ()> =
+        TypedTransform3D::create_rotation(0.0, 1.0, 0.0, Radians::new(-FRAC_PI_4));
+    let transform1: TypedTransform3D<f32, (), ()> =
+        TypedTransform3D::create_rotation(0.0, 1.0, 0.0, Radians::new(0.0));
+    let transform2: TypedTransform3D<f32, (), ()> =
+        TypedTransform3D::create_rotation(0.0, 1.0, 0.0, Radians::new(FRAC_PI_4));
 
-    let rect: TypedRect<f32, ()> = TypedRect::new(TypedPoint2D::new(-10.0, -10.0), TypedSize2D::new(20.0, 20.0));
+    let rect: TypedRect<f32, ()> = euclid::rect(-10.0, -10.0, 20.0, 20.0);
     let polys = [
         Polygon::from_transformed_rect(rect, transform0, 0),
         Polygon::from_transformed_rect(rect, transform1, 1),
         Polygon::from_transformed_rect(rect, transform2, 2),
     ];
 
-    let result = splitter.solve(&polys, TypedPoint3D::new(0.0, 0.0, -1.0));
+    let result = splitter.solve(&polys, vec3(0.0, 0.0, -1.0));
     let ids: Vec<_> = result.iter().map(|poly| poly.anchor).collect();
     assert_eq!(&ids, &[2, 1, 0, 1, 2]);
 }
@@ -56,13 +56,13 @@ fn rotation_bsp() {
 
 fn sort_trivial(splitter: &mut Splitter<f32, ()>) {
     let anchors: Vec<_> = (0usize .. 10).collect();
-    let rect: TypedRect<f32, ()> = TypedRect::new(TypedPoint2D::new(-10.0, -10.0), TypedSize2D::new(20.0, 20.0));
+    let rect: TypedRect<f32, ()> = euclid::rect(-10.0, -10.0, 20.0, 20.0);
     let polys: Vec<_> = anchors.iter().map(|&anchor| {
-        let transform: TypedMatrix4D<f32, (), ()> = TypedMatrix4D::create_translation(0.0, 0.0, anchor as f32);
+        let transform: TypedTransform3D<f32, (), ()> = TypedTransform3D::create_translation(0.0, 0.0, anchor as f32);
         Polygon::from_transformed_rect(rect, transform, anchor)
     }).collect();
 
-    let result = splitter.solve(&polys, TypedPoint3D::new(0.0, 0.0, -1.0));
+    let result = splitter.solve(&polys, vec3(0.0, 0.0, -1.0));
     let anchors1: Vec<_> = result.iter().map(|p| p.anchor).collect();
     let mut anchors2 = anchors1.clone();
     anchors2.sort_by_key(|&a| -(a as i32));


### PR DESCRIPTION
This is a very hipster type of pull request because euclid 0.14 isn't published yet on crates.io. But getting all of servo's use of euclid converted to 0.14 is going to be acrobatic, so I am getting started.

Since euclid 0.14 isn't published yet, you need to add

```
[replace]
"euclid:0.13.0" = { path = "path/to/a/local/clone/of/euclid" }
```

to Cargo.toml until 0.14 finds its way to crates.io.

No need to land this before that happens but I need to at least have this fixed up locally to start fixing webrender so I had to get started asap.

Since conversion to 0.14 is a lot of work (and a lot of crates), I only converted point to vectors where it seemed to make sense. There's probably some other more stylistic that could make sense (like using `vec3` and other helpers), but I propose that we postpone that to followups.

Note that I added a comment somewhere in a place where we add two points to compute the origin of a line and I am not sure what this means, so this bit should be reviewed with special care.

Edit: got mixed up between 0.13 and 0.14