### PR TITLE
Polygon from_points

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plane-split"
-version = "0.8.0"
+version = "0.8.1"
 description = "Plane splitting"
 authors = ["Dzmitry Malyshau <kvark@mozilla.com>"]
 license = "MPL-2.0"

--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@
 [![](http://meritbadge.herokuapp.com/plane-split)](https://crates.io/crates/plane-split)
 [![Documentation](https://docs.rs/plane-split/badge.svg)](https://docs.rs/plane-split)
 
-Plane splitting with [euclid](https://crates.io/crates/euclid).
+Plane splitting with [euclid](https://crates.io/crates/euclid), made for [WebRender](https://github.com/servo/webrender/).

--- a/src/naive.rs
+++ b/src/naive.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use std::{fmt, ops};
 use std::cmp::Ordering;
 use {Intersection, Line, Polygon, Splitter};
@@ -7,6 +9,7 @@ use num_traits::{Float, One, Zero};
 
 
 /// Naive plane splitter, has at least O(n^2) complexity.
+#[deprecated]
 pub struct NaiveSplitter<T, U> {
     result: Vec<Polygon<T, U>>,
     current: Vec<Polygon<T, U>>,

--- a/tests/split.rs
+++ b/tests/split.rs
@@ -3,18 +3,13 @@ extern crate plane_split;
 
 use std::f32::consts::FRAC_PI_4;
 use euclid::{Angle, TypedTransform3D, TypedRect, vec3};
-use plane_split::{BspSplitter, NaiveSplitter, Polygon, Splitter, _make_grid};
+use plane_split::{BspSplitter, Polygon, Splitter, _make_grid};
 
 
 fn grid_impl(count: usize, splitter: &mut Splitter<f32, ()>) {
     let polys = _make_grid(count);
     let result = splitter.solve(&polys, vec3(0.0, 0.0, 1.0));
     assert_eq!(result.len(), count + count*count + count*count*count);
-}
-
-#[test]
-fn grid_naive() {
-    grid_impl(2, &mut NaiveSplitter::new());
 }
 
 #[test]
@@ -44,11 +39,6 @@ fn sort_rotation(splitter: &mut Splitter<f32, ()>) {
 }
 
 #[test]
-fn rotation_naive() {
-    sort_rotation(&mut NaiveSplitter::new());
-}
-
-#[test]
 fn rotation_bsp() {
     sort_rotation(&mut BspSplitter::new());
 }
@@ -67,11 +57,6 @@ fn sort_trivial(splitter: &mut Splitter<f32, ()>) {
     let mut anchors2 = anchors1.clone();
     anchors2.sort_by_key(|&a| -(a as i32));
     assert_eq!(anchors1, anchors2); //make sure Z is sorted backwards
-}
-
-#[test]
-fn trivial_naive() {
-    sort_trivial(&mut NaiveSplitter::new());
 }
 
 #[test]


### PR DESCRIPTION
Adds a simple constructor to `Polygon` and cleans up a bit of a style. Also attempts to phase out `NaiveSplitter`.