### PR TITLE
Update euclid to 0.18 and bump version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plane-split"
-version = "0.9.1"
+version = "0.10.0"
 description = "Plane splitting"
 authors = ["Dzmitry Malyshau <kvark@mozilla.com>"]
 license = "MPL-2.0"
@@ -10,6 +10,6 @@ documentation = "https://docs.rs/plane-split"
 
 [dependencies]
 binary-space-partition = "0.1.2"
-euclid = "0.17"
+euclid = "0.18"
 log = "0.4"
 num-traits = {version = "0.1.37", default-features = false}

--- a/src/polygon.rs
+++ b/src/polygon.rs
@@ -143,21 +143,21 @@ impl<T, U> Polygon<T, U> where
         rect: TypedRect<T, V>,
         transform: TypedTransform3D<T, V, U>,
         anchor: usize,
-    ) -> Self
+    ) -> Option<Self>
     where
         T: Trig + ops::Neg<Output=T>,
     {
         let points = [
-            transform.transform_point3d(&rect.origin.to_3d()),
-            transform.transform_point3d(&rect.top_right().to_3d()),
-            transform.transform_point3d(&rect.bottom_right().to_3d()),
-            transform.transform_point3d(&rect.bottom_left().to_3d()),
+            transform.transform_point3d(&rect.origin.to_3d())?,
+            transform.transform_point3d(&rect.top_right().to_3d())?,
+            transform.transform_point3d(&rect.bottom_right().to_3d())?,
+            transform.transform_point3d(&rect.bottom_left().to_3d())?,
         ];
 
         //Note: this code path could be more efficient if we had inverse-transpose
         //let n4 = transform.transform_point4d(&TypedPoint4D::new(T::zero(), T::zero(), T::one(), T::zero()));
         //let normal = TypedPoint3D::new(n4.x, n4.y, n4.z);
-        Self::from_points(points, anchor)
+        Some(Self::from_points(points, anchor))
     }
 
     /// Bring a point into the local coordinate space, returning

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -65,7 +65,7 @@ fn from_transformed_rect() {
         TypedTransform3D::create_rotation(0.5f32.sqrt(), 0.0, 0.5f32.sqrt(), Angle::radians(5.0))
         .pre_translate(vec3(0.0, 0.0, 10.0));
     let poly = Polygon::from_transformed_rect(rect, transform, 0);
-    assert!(poly.is_valid());
+    assert!(poly.is_some() && poly.unwrap().is_valid());
 }
 
 #[test]

--- a/tests/split.rs
+++ b/tests/split.rs
@@ -27,12 +27,12 @@ fn sort_rotation(splitter: &mut Splitter<f32, ()>) {
         TypedTransform3D::create_rotation(0.0, 1.0, 0.0, Angle::radians(FRAC_PI_4));
 
     let rect: TypedRect<f32, ()> = euclid::rect(-10.0, -10.0, 20.0, 20.0);
-    let polys = [
-        Polygon::from_transformed_rect(rect, transform0, 0),
-        Polygon::from_transformed_rect(rect, transform1, 1),
-        Polygon::from_transformed_rect(rect, transform2, 2),
-    ];
+    let p1 = Polygon::from_transformed_rect(rect, transform0, 0);
+    let p2 = Polygon::from_transformed_rect(rect, transform1, 1);
+    let p3 = Polygon::from_transformed_rect(rect, transform2, 2);
+    assert!(p1.is_some() && p2.is_some() && p3.is_some(), "Cannot construct transformed polygons");
 
+    let polys = [ p1.unwrap(), p2.unwrap(), p3.unwrap() ];
     let result = splitter.solve(&polys, vec3(0.0, 0.0, -1.0));
     let ids: Vec<_> = result.iter().map(|poly| poly.anchor).collect();
     assert_eq!(&ids, &[2, 1, 0, 1, 2]);
@@ -49,7 +49,9 @@ fn sort_trivial(splitter: &mut Splitter<f32, ()>) {
     let rect: TypedRect<f32, ()> = euclid::rect(-10.0, -10.0, 20.0, 20.0);
     let polys: Vec<_> = anchors.iter().map(|&anchor| {
         let transform: TypedTransform3D<f32, (), ()> = TypedTransform3D::create_translation(0.0, 0.0, anchor as f32);
-        Polygon::from_transformed_rect(rect, transform, anchor)
+        let poly = Polygon::from_transformed_rect(rect, transform, anchor);
+        assert!(poly.is_some(), "Cannot construct transformed polygons");
+        poly.unwrap()
     }).collect();
 
     let result = splitter.solve(&polys, vec3(0.0, 0.0, -1.0));


### PR DESCRIPTION
"euclid:0.18" changes the output type of `TypedTransform3D::transform_point3d()` to `Option<...>`, so we also update the output type of `Polygon::from_transformed_rect()` to `Option<...>`.

I would like to use the new euclid (i.e. 0.18), so it's better to bump euclid for all crates we need on Gecko. 