### PR TITLE
Recognize empty polygons

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plane-split"
-version = "0.12.0"
+version = "0.12.1"
 description = "Plane splitting"
 authors = ["Dzmitry Malyshau <kvark@mozilla.com>"]
 license = "MPL-2.0"

--- a/src/bsp.rs
+++ b/src/bsp.rs
@@ -5,7 +5,7 @@ use euclid::{TypedPoint3D, TypedVector3D};
 use euclid::approxeq::ApproxEq;
 use num_traits::{Float, One, Zero};
 
-use std::{fmt, ops};
+use std::{fmt, iter, ops};
 
 
 impl<T, U> BspPlane for Polygon<T, U> where
@@ -43,7 +43,11 @@ impl<T, U> BspPlane for Polygon<T, U> where
                 let mut front = Vec::new();
                 let mut back = Vec::new();
 
-                for sub in Some(plane).into_iter().chain(res_add1).chain(res_add2) {
+                for sub in iter::once(plane)
+                    .chain(res_add1)
+                    .chain(res_add2)
+                    .filter(|p| !p.is_empty())
+                {
                     if self.plane.signed_distance_sum_to(&sub) > T::zero() {
                         front.push(sub)
                     } else {
@@ -54,8 +58,8 @@ impl<T, U> BspPlane for Polygon<T, U> where
                     line, front.len(), back.len());
 
                 PlaneCut::Cut {
-                    front: front,
-                    back: back,
+                    front,
+                    back,
                 }
             },
         }

--- a/src/clip.rs
+++ b/src/clip.rs
@@ -131,6 +131,6 @@ impl<
         }
         self.results
             .drain(..)
-            .map(move |poly| poly.transform(transform).unwrap())
+            .flat_map(move |poly| poly.transform(transform))
     }
 }

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -59,6 +59,20 @@ fn valid() {
 }
 
 #[test]
+fn empty() {
+    let poly = Polygon::<f32, ()>::try_from_points(
+        [
+            point3(0.0, 0.0, 1.0),
+            point3(0.0, 0.0, 1.0),
+            point3(0.0, 0.00001, 1.0),
+            point3(1.0, 0.0, 0.0),
+        ],
+        1,
+    );
+    assert_eq!(None, poly);
+}
+
+#[test]
 fn from_transformed_rect() {
     let rect: TypedRect<f32, ()> = TypedRect::new(point2(10.0, 10.0), TypedSize2D::new(20.0, 30.0));
     let transform: TypedTransform3D<f32, (), ()> =


### PR DESCRIPTION
The try push errors are caused by redundant rectangles produced. This PR tries to filter them out without being a breaking change.