### PR TITLE
Consistent construction of transformed polygons, better coplanar detection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plane-split"
-version = "0.13.0"
+version = "0.13.1"
 description = "Plane splitting"
 authors = ["Dzmitry Malyshau <kvark@mozilla.com>"]
 license = "MPL-2.0"

--- a/src/bsp.rs
+++ b/src/bsp.rs
@@ -1,4 +1,5 @@
 use {Intersection, Plane, Polygon, Splitter};
+use is_zero;
 
 use binary_space_partition::{BspNode, Plane as BspPlane, PlaneCut};
 use euclid::{TypedPoint3D, TypedVector3D};
@@ -18,15 +19,29 @@ impl<T, U> BspPlane for Polygon<T, U> where
     fn cut(&self, mut poly: Self) -> PlaneCut<Self> {
         debug!("\tCutting anchor {} by {}", poly.anchor, self.anchor);
         trace!("\t\tbase {:?}", self.plane);
-        let dist = self.plane.signed_distance_sum_to(&poly);
 
-        match self.intersect(&poly) {
-            Intersection::Coplanar if dist.approx_eq(&T::zero()) => {
-                debug!("\t\tCoplanar and matching (dist = {:?})", dist);
+        let (intersection, dist) = if self.plane.normal
+            .dot(poly.plane.normal)
+            .approx_eq(&T::one())
+        {
+            debug!("\t\tNormals roughly match");
+            (Intersection::Coplanar, self.plane.offset - poly.plane.offset)
+        } else {
+            let is = self.intersect(&poly);
+            let dist = self.plane.signed_distance_sum_to(&poly);
+            (is, dist)
+        };
+
+        match intersection {
+            //Note: we deliberately make the comparison wider than just with T::epsilon().
+            // This is done to avoid mistakenly ordering items that should be on the same
+            // plane but end up slightly different due to the floating point precision.
+            Intersection::Coplanar if is_zero(dist) => {
+                debug!("\t\tCoplanar at {:?}", dist);
                 PlaneCut::Sibling(poly)
             }
             Intersection::Coplanar | Intersection::Outside => {
-                debug!("\t\tCoplanar at {:?}", dist);
+                debug!("\t\tOutside at {:?}", dist);
                 if dist > T::zero() {
                     PlaneCut::Cut {
                         front: vec![poly],

--- a/src/polygon.rs
+++ b/src/polygon.rs
@@ -161,15 +161,19 @@ impl<T, U> Polygon<T, U> where
 
     /// Construct a polygon from a non-transformed rectangle.
     pub fn from_rect(rect: TypedRect<T, U>, anchor: usize) -> Self {
-        Self::from_points(
-            [
+        Polygon {
+            points: [
                 rect.origin.to_3d(),
                 rect.top_right().to_3d(),
                 rect.bottom_right().to_3d(),
                 rect.bottom_left().to_3d(),
             ],
+            plane: Plane {
+                normal: TypedVector3D::new(T::zero(), T::zero(), T::one()),
+                offset: T::zero(),
+            },
             anchor,
-        ).unwrap()
+        }
     }
 
     /// Construct a polygon from a rectangle with 3D transform.

--- a/src/polygon.rs
+++ b/src/polygon.rs
@@ -187,11 +187,46 @@ impl<T, U> Polygon<T, U> where
             transform.transform_point3d(&rect.bottom_right().to_3d())?,
             transform.transform_point3d(&rect.bottom_left().to_3d())?,
         ];
-
-        //Note: this code path could be more efficient if we had inverse-transpose
-        //let n4 = transform.transform_point4d(&TypedPoint4D::new(T::zero(), T::zero(), T::one(), T::zero()));
-        //let normal = TypedPoint3D::new(n4.x, n4.y, n4.z);
         Self::from_points(points, anchor)
+    }
+
+    /// Construct a polygon from a rectangle with an invertible 3D transform.
+    pub fn from_transformed_rect_with_inverse<V>(
+        rect: TypedRect<T, V>,
+        transform: &TypedTransform3D<T, V, U>,
+        inv_transform: &TypedTransform3D<T, U, V>,
+        anchor: usize,
+    ) -> Option<Self>
+    where
+        T: Trig + ops::Neg<Output=T>,
+    {
+        let points = [
+            transform.transform_point3d(&rect.origin.to_3d())?,
+            transform.transform_point3d(&rect.top_right().to_3d())?,
+            transform.transform_point3d(&rect.bottom_right().to_3d())?,
+            transform.transform_point3d(&rect.bottom_left().to_3d())?,
+        ];
+
+        // Compute the normal directly from the transformation. This guarantees consistent polygons
+        // generated from various local rectanges on the same geometry plane.
+        let normal_raw = TypedVector3D::new(inv_transform.m13, inv_transform.m23, inv_transform.m33);
+        let normal_sql = normal_raw.square_length();
+        if normal_sql.approx_eq(&T::zero()) {
+            None
+        } else {
+            let normal = normal_raw / normal_sql.sqrt();
+            let offset = -TypedVector3D::new(transform.m41, transform.m42, transform.m43)
+                .dot(normal) * transform.m44;
+
+            Some(Polygon {
+                points,
+                plane: Plane {
+                    normal,
+                    offset,
+                },
+                anchor,
+            })
+        }
     }
 
     /// Bring a point into the local coordinate space, returning

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -78,8 +78,14 @@ fn from_transformed_rect() {
     let transform: TypedTransform3D<f32, (), ()> =
         TypedTransform3D::create_rotation(0.5f32.sqrt(), 0.0, 0.5f32.sqrt(), Angle::radians(5.0))
         .pre_translate(vec3(0.0, 0.0, 10.0));
-    let poly = Polygon::from_transformed_rect(rect, transform, 0);
-    assert!(poly.is_some() && poly.unwrap().is_valid());
+    let poly = Polygon::from_transformed_rect(rect, transform, 0).unwrap();
+    assert!(poly.is_valid());
+
+    let inv_transform = transform.inverse().unwrap();
+    let poly2 = Polygon::from_transformed_rect_with_inverse(rect, &transform, &inv_transform, 0).unwrap();
+    assert_eq!(poly.points, poly2.points);
+    assert!(poly.plane.offset.approx_eq(&poly2.plane.offset));
+    assert!(poly.plane.normal.dot(poly2.plane.normal).approx_eq(&1.0));
 }
 
 #[test]


### PR DESCRIPTION
This PR brings a number of fixes related to https://github.com/servo/webrender/issues/3070
  - better logging
  - new method of transforming a polygon that receives the inverse transform. It guarantees that the actual plane of the polygon is consistent, no matter what the actual local points are. This helps deal with precision issues.
  - detect if polygons are co-planar earlier, and allow for wider gap between the planes, which forces original ordering of elements