### PR TITLE
Fix coplanar plane detection, regressed by last PR

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plane-split"
-version = "0.13.5"
+version = "0.13.6"
 description = "Plane splitting"
 authors = ["Dzmitry Malyshau <kvark@mozilla.com>"]
 license = "MPL-2.0"

--- a/src/bsp.rs
+++ b/src/bsp.rs
@@ -21,21 +21,21 @@ impl<T, U> BspPlane for Polygon<T, U> where
         trace!("\t\tbase {:?}", self.plane);
 
         //Note: we treat `self` as a plane, and `poly` as a concrete polygon here
-        let (intersection, dist) = if self.plane.are_outside(&poly.points) {
-            let dist = self.plane.signed_distance_sum_to(&poly);
-            (Intersection::Outside, dist)
-        } else {
-            match self.plane.intersect(&poly.plane) {
-                Some(line) => {
-                    //Note: distance isn't relevant here
-                    (Intersection::Inside(line), T::zero())
-                }
-                None => {
-                    let ndot = self.plane.normal.dot(poly.plane.normal);
-                    debug!("\t\tNormals are aligned with {:?}", ndot);
-                    let dist = self.plane.offset - ndot * poly.plane.offset;
-                    (Intersection::Coplanar, dist)
-                }
+        let (intersection, dist) = match self.plane.intersect(&poly.plane) {
+            None => {
+                let ndot = self.plane.normal.dot(poly.plane.normal);
+                debug!("\t\tNormals are aligned with {:?}", ndot);
+                let dist = self.plane.offset - ndot * poly.plane.offset;
+                (Intersection::Coplanar, dist)
+            }
+            Some(_) if self.plane.are_outside(&poly.points) => {
+                //Note: we can't start with `are_outside` because it's subject to FP precision
+                let dist = self.plane.signed_distance_sum_to(&poly);
+                (Intersection::Outside, dist)
+            }
+            Some(line) => {
+                //Note: distance isn't relevant here
+                (Intersection::Inside(line), T::zero())
             }
         };
 

--- a/tests/split.rs
+++ b/tests/split.rs
@@ -95,22 +95,34 @@ fn test_cut() {
     let rect: TypedRect<f32, ()> = rect(-10.0, -10.0, 20.0, 20.0);
     let poly = Polygon::from_rect(rect, 0);
     let mut poly2 = Polygon::from_rect(rect, 0);
+    // test robustness for positions
+    for p in &mut poly2.points {
+        p.z += 0.00000001;
+    }
+    match poly.cut(poly2.clone()) {
+        PlaneCut::Sibling(p) => assert_eq!(p, poly2),
+        PlaneCut::Cut { .. } => panic!("wrong cut!"),
+    }
+    // test robustness for normal
     poly2.plane.normal.z += 0.00000001;
     match poly.cut(poly2.clone()) {
         PlaneCut::Sibling(p) => assert_eq!(p, poly2),
         PlaneCut::Cut { .. } => panic!("wrong cut!"),
     }
+    // test opposite normal handling
     poly2.plane.normal *= -1.0;
     match poly.cut(poly2.clone()) {
         PlaneCut::Sibling(p) => assert_eq!(p, poly2),
         PlaneCut::Cut { .. } => panic!("wrong cut!"),
     }
 
+    // test grouping front
     poly2.plane.offset += 0.1;
     match poly.cut(poly2.clone()) {
         PlaneCut::Cut { ref front, ref back } => assert_eq!((front.len(), back.len()), (1, 0)),
         PlaneCut::Sibling(_) => panic!("wrong sibling!"),
     }
+    // test grouping back
     poly2.plane.normal *= -1.0;
     match poly.cut(poly2.clone()) {
         PlaneCut::Cut { ref front, ref back } => assert_eq!((front.len(), back.len()), (0, 1)),


### PR DESCRIPTION
Basically reverts 0050a48372e178bee2c4c0b7128937d4aaf746e3
Also adds a test that covers the regression.
Reason: calling `are_outside` there is subject to floating-point imperfections.