### PR TITLE
Try to intersect planes more aggressively

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plane-split"
-version = "0.14.0"
+version = "0.14.1"
 description = "Plane splitting"
 authors = ["Dzmitry Malyshau <kvark@mozilla.com>"]
 license = "MPL-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -196,13 +196,12 @@ impl<
         // v = (d2*w - d1) / (1 - w*w) * n1 - (d2 - d1*w) / (1 - w*w) * n2
         let w = self.normal.dot(other.normal);
         let divisor = T::one() - w * w;
-        if divisor < T::approx_epsilon() {
+        if divisor < T::approx_epsilon() * T::approx_epsilon() {
             return None
         }
-        let factor = T::one() / divisor;
         let origin = Point3D::origin() +
-            self.normal * ((other.offset * w - self.offset) * factor) -
-            other.normal* ((other.offset - self.offset * w) * factor);
+            self.normal * ((other.offset * w - self.offset) / divisor) -
+            other.normal* ((other.offset - self.offset * w) / divisor);
 
         let cross_dir = self.normal.cross(other.normal);
         // note: the cross product isn't too close to zero

--- a/tests/clip.rs
+++ b/tests/clip.rs
@@ -122,3 +122,23 @@ fn clip_badly_transformed() {
     let results = clipper.clip_transformed(polygon, &tx, None);
     assert!(results.is_err());
 }
+
+#[test]
+fn clip_near_coplanar() {
+    let tx = Transform3D::<f32, (), ()>::row_major(
+        1.0, 0.0, 0.0, 0.0,
+        0.0, 1.0, 0.0, 0.0,
+        -960.0, -625.0, 1.0, -1.0,
+        100.0, -2852.0, 0.0, 1.0,
+    );
+    let mut clipper = Clipper::new();
+    let polygon = Polygon::from_rect(rect(0.0, 0.0, 1703.0, 4020.0), 0);
+
+    let bounds1 = rect(0.0, -430.0, 2048.0, 2048.0);
+    let results1 = clipper.clip_transformed(polygon.clone(), &tx, Some(bounds1));
+    assert_ne!(0, results1.unwrap().count());
+
+    let bounds2 = rect(0.0, 0.0, 816.0, 1039.0);
+    let results2 = clipper.clip_transformed(polygon, &tx, Some(bounds2));
+    assert_ne!(0, results2.unwrap().count());
+}


### PR DESCRIPTION
Comparing `divisor` to epsilon is unfair, since the divisor contains a squared dot product. This changes makes it compare against the squared epsilon. In order to assist the precision of those extra cases, we are no longer trying to store 1 / divisor before doing the point computation.

pending gecko try with the plane-split local override:
https://treeherder.mozilla.org/#/jobs?repo=try&revision=3c88731bd2026c8d45af2bbe58b3fe3efff04e26