### PR TITLE
Rewrite the BSP tree

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plane-split"
-version = "0.17.1"
+version = "0.18.0"
 description = "Plane splitting"
 authors = ["Dzmitry Malyshau <kvark@mozilla.com>"]
 license = "MPL-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,4 @@ edition = "2018"
 [dependencies]
 euclid = "0.22"
 log = "0.4"
+smallvec = "1.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,3 @@ edition = "2018"
 [dependencies]
 euclid = "0.22"
 log = "0.4"
-num-traits = { version = "0.2", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ documentation = "https://docs.rs/plane-split"
 edition = "2018"
 
 [dependencies]
-binary-space-partition = "0.1.2"
 euclid = "0.22"
 log = "0.4"
 num-traits = { version = "0.2", default-features = false }

--- a/benches/split.rs
+++ b/benches/split.rs
@@ -5,7 +5,7 @@ extern crate plane_split;
 extern crate test;
 
 use euclid::vec3;
-use plane_split::{make_grid, BspSplitter, Splitter};
+use plane_split::{make_grid, BspSplitter};
 use std::sync::Arc;
 
 #[bench]

--- a/src/bsp.rs
+++ b/src/bsp.rs
@@ -1,10 +1,18 @@
 use crate::{is_zero, Intersection, Plane, Polygon, Splitter};
 
-use binary_space_partition::{BspNode, Plane as BspPlane, PlaneCut};
 use euclid::{approxeq::ApproxEq, Point3D, Vector3D};
 use num_traits::{Float, One, Zero};
 
 use std::{fmt, iter, ops};
+
+/// A plane abstracted to the matter of partitioning.
+pub trait BspPlane: Sized + Clone {
+    /// Try to cut a different plane by this one.
+    fn cut(&self, other: Self) -> PlaneCut<Self>;
+    /// Check if a different plane is aligned in the same direction
+    /// as this one.
+    fn is_aligned(&self, otgher: &Self) -> bool;
+}
 
 impl<T, U, A> BspPlane for Polygon<T, U, A>
 where
@@ -148,5 +156,94 @@ where
         self.result.clear();
         self.tree.order(&poly, &mut self.result);
         &self.result
+    }
+}
+
+/// The result of one plane being cut by another one.
+/// The "cut" here is an attempt to classify a plane as being
+/// in front or in the back of another one.
+#[derive(Debug)]
+pub enum PlaneCut<T> {
+    /// The planes are one the same geometrical plane.
+    Sibling(T),
+    /// Planes are different, thus we can either determine that
+    /// our plane is completely in front/back of another one,
+    /// or split it into these sub-groups.
+    Cut {
+        /// Sub-planes in front of the base plane.
+        front: Vec<T>,
+        /// Sub-planes in the back of the base plane.
+        back: Vec<T>,
+    },
+}
+
+/// Add a list of planes to a particular front/end branch of some root node.
+fn add_side<T: BspPlane>(side: &mut Option<Box<BspNode<T>>>, mut planes: Vec<T>) {
+    if planes.len() != 0 {
+        if side.is_none() {
+            *side = Some(Box::new(BspNode::new()));
+        }
+        let node = side.as_mut().unwrap();
+        for p in planes.drain(..) {
+            node.insert(p)
+        }
+    }
+}
+
+/// A node in the `BspTree`, which can be considered a tree itself.
+#[derive(Clone, Debug)]
+pub struct BspNode<T> {
+    values: Vec<T>,
+    front: Option<Box<BspNode<T>>>,
+    back: Option<Box<BspNode<T>>>,
+}
+
+impl<T> BspNode<T> {
+    /// Create a new node.
+    pub fn new() -> Self {
+        BspNode {
+            values: Vec::new(),
+            front: None,
+            back: None,
+        }
+    }
+}
+
+impl<T: BspPlane> BspNode<T> {
+    /// Insert a value into the sub-tree starting with this node.
+    /// This operation may spawn additional leafs/branches of the tree.
+    pub fn insert(&mut self, value: T) {
+        if self.values.is_empty() {
+            self.values.push(value);
+            return;
+        }
+        match self.values[0].cut(value) {
+            PlaneCut::Sibling(value) => self.values.push(value),
+            PlaneCut::Cut { front, back } => {
+                add_side(&mut self.front, front);
+                add_side(&mut self.back, back);
+            }
+        }
+    }
+
+    /// Build the draw order of this sub-tree into an `out` vector,
+    /// so that the contained planes are sorted back to front according
+    /// to the view vector defined as the `base` plane front direction.
+    pub fn order(&self, base: &T, out: &mut Vec<T>) {
+        let (former, latter) = match self.values.first() {
+            None => return,
+            Some(ref first) if base.is_aligned(first) => (self.front.as_ref(), self.back.as_ref()),
+            Some(_) => (self.back.as_ref(), self.front.as_ref()),
+        };
+
+        if let Some(ref node) = former {
+            node.order(base, out);
+        }
+
+        out.extend_from_slice(&self.values);
+
+        if let Some(ref node) = latter {
+            node.order(base, out);
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ mod bsp;
 mod clip;
 mod polygon;
 
-pub use bsp::PlaneCut;
+pub use polygon::PlaneCut;
 
 use euclid::{
     approxeq::ApproxEq,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,8 +16,10 @@ mod polygon;
 
 pub use bsp::{BspPlane, PlaneCut};
 
-use euclid::{approxeq::ApproxEq, Point3D, Scale, Vector3D};
-use num_traits::{Float, One, Zero};
+use euclid::{
+    approxeq::ApproxEq,
+    default::{Point3D, Scale, Vector3D},
+};
 
 use std::ops;
 
@@ -25,48 +27,28 @@ pub use self::bsp::BspSplitter;
 pub use self::clip::Clipper;
 pub use self::polygon::{Intersection, LineProjection, Polygon};
 
-fn is_zero<T>(value: T) -> bool
-where
-    T: Copy + Zero + ApproxEq<T> + ops::Mul<T, Output = T>,
-{
+fn is_zero(value: f64) -> bool {
     //HACK: this is rough, but the original Epsilon is too strict
-    (value * value).approx_eq(&T::zero())
+    (value * value).approx_eq(&0.0)
 }
 
-fn is_zero_vec<T, U>(vec: Vector3D<T, U>) -> bool
-where
-    T: Copy
-        + Zero
-        + ApproxEq<T>
-        + ops::Add<T, Output = T>
-        + ops::Sub<T, Output = T>
-        + ops::Mul<T, Output = T>,
-{
-    vec.dot(vec).approx_eq(&T::zero())
+fn is_zero_vec(vec: Vector3D<f64>) -> bool {
+    vec.dot(vec).approx_eq(&0.0)
 }
 
 /// A generic line.
 #[derive(Debug)]
-pub struct Line<T, U> {
+pub struct Line {
     /// Arbitrary point on the line.
-    pub origin: Point3D<T, U>,
+    pub origin: Point3D<f64>,
     /// Normalized direction of the line.
-    pub dir: Vector3D<T, U>,
+    pub dir: Vector3D<f64>,
 }
 
-impl<T, U> Line<T, U>
-where
-    T: Copy
-        + One
-        + Zero
-        + ApproxEq<T>
-        + ops::Add<T, Output = T>
-        + ops::Sub<T, Output = T>
-        + ops::Mul<T, Output = T>,
-{
+impl Line {
     /// Check if the line has consistent parameters.
     pub fn is_valid(&self) -> bool {
-        is_zero(self.dir.dot(self.dir) - T::one())
+        is_zero(self.dir.dot(self.dir) - 1.0)
     }
     /// Check if two lines match each other.
     pub fn matches(&self, other: &Self) -> bool {
@@ -76,10 +58,7 @@ where
 
     /// Intersect an edge given by the end points.
     /// Returns the fraction of the edge where the intersection occurs.
-    fn intersect_edge(&self, edge: ops::Range<Point3D<T, U>>) -> Option<T>
-    where
-        T: ops::Div<T, Output = T>,
-    {
+    fn intersect_edge(&self, edge: ops::Range<Point3D<f64>>) -> Option<f64> {
         let edge_vec = edge.end - edge.start;
         let origin_vec = self.origin - edge.start;
         // edge.start + edge_vec * t = r + k * d
@@ -89,7 +68,7 @@ where
         let pr = origin_vec - self.dir * self.dir.dot(origin_vec);
         let pb = edge_vec - self.dir * self.dir.dot(edge_vec);
         let denom = pb.dot(pb);
-        if denom.approx_eq(&T::zero()) {
+        if denom.approx_eq(&0.0) {
             None
         } else {
             Some(pr.dot(pb) / denom)
@@ -102,15 +81,15 @@ where
 /// When used for plane splitting, it's defining a hemisphere
 /// with equation "dot(v, normal) + offset > 0".
 #[derive(Debug, PartialEq)]
-pub struct Plane<T, U> {
+pub struct Plane {
     /// Normalized vector perpendicular to the plane.
-    pub normal: Vector3D<T, U>,
+    pub normal: Vector3D<f64>,
     /// Constant offset from the normal plane, specified in the
     /// direction opposite to the normal.
-    pub offset: T,
+    pub offset: f64,
 }
 
-impl<T: Clone, U> Clone for Plane<T, U> {
+impl Clone for Plane {
     fn clone(&self) -> Self {
         Plane {
             normal: self.normal.clone(),
@@ -124,33 +103,21 @@ impl<T: Clone, U> Clone for Plane<T, U> {
 #[derive(Clone, Debug, Hash, PartialEq, PartialOrd)]
 pub struct NegativeHemisphereError;
 
-impl<
-        T: Copy
-            + Zero
-            + One
-            + Float
-            + ApproxEq<T>
-            + ops::Sub<T, Output = T>
-            + ops::Add<T, Output = T>
-            + ops::Mul<T, Output = T>
-            + ops::Div<T, Output = T>,
-        U,
-    > Plane<T, U>
-{
+impl Plane {
     /// Construct a new plane from unnormalized equation.
     pub fn from_unnormalized(
-        normal: Vector3D<T, U>,
-        offset: T,
+        normal: Vector3D<f64>,
+        offset: f64,
     ) -> Result<Option<Self>, NegativeHemisphereError> {
         let square_len = normal.square_length();
-        if square_len < T::approx_epsilon() * T::approx_epsilon() {
-            if offset > T::zero() {
+        if square_len < f64::approx_epsilon() * f64::approx_epsilon() {
+            if offset > 0.0 {
                 Ok(None)
             } else {
                 Err(NegativeHemisphereError)
             }
         } else {
-            let kf = T::one() / square_len.sqrt();
+            let kf = 1.0 / square_len.sqrt();
             Ok(Some(Plane {
                 normal: normal * Scale::new(kf),
                 offset: offset * kf,
@@ -167,49 +134,46 @@ impl<
     /// Return the signed distance from this plane to a point.
     /// The distance is negative if the point is on the other side of the plane
     /// from the direction of the normal.
-    pub fn signed_distance_to(&self, point: &Point3D<T, U>) -> T {
+    pub fn signed_distance_to(&self, point: &Point3D<f64>) -> f64 {
         point.to_vector().dot(self.normal) + self.offset
     }
 
     /// Compute the distance across the line to the plane plane,
     /// starting from the line origin.
-    pub fn distance_to_line(&self, line: &Line<T, U>) -> T
-    where
-        T: ops::Neg<Output = T>,
-    {
+    pub fn distance_to_line(&self, line: &Line) -> f64 {
         self.signed_distance_to(&line.origin) / -self.normal.dot(line.dir)
     }
 
     /// Compute the sum of signed distances to each of the points
     /// of another plane. Useful to know the relation of a plane that
     /// is a product of a split, and we know it doesn't intersect `self`.
-    pub fn signed_distance_sum_to<A>(&self, poly: &Polygon<T, U, A>) -> T {
+    pub fn signed_distance_sum_to<A>(&self, poly: &Polygon<A>) -> f64 {
         poly.points
             .iter()
-            .fold(T::zero(), |u, p| u + self.signed_distance_to(p))
+            .fold(0.0, |u, p| u + self.signed_distance_to(p))
     }
 
     /// Check if a convex shape defined by a set of points is completely
     /// outside of this plane. Merely touching the surface is not
     /// considered an intersection.
-    pub fn are_outside(&self, points: &[Point3D<T, U>]) -> bool {
+    pub fn are_outside(&self, points: &[Point3D<f64>]) -> bool {
         let d0 = self.signed_distance_to(&points[0]);
         points[1..]
             .iter()
-            .all(|p| self.signed_distance_to(p) * d0 > T::zero())
+            .all(|p| self.signed_distance_to(p) * d0 > 0.0)
     }
 
     //TODO(breaking): turn this into Result<Line, DotProduct>
     /// Compute the line of intersection with another plane.
-    pub fn intersect(&self, other: &Self) -> Option<Line<T, U>> {
+    pub fn intersect(&self, other: &Self) -> Option<Line> {
         // compute any point on the intersection between planes
         // (n1, v) + d1 = 0
         // (n2, v) + d2 = 0
         // v = a*n1/w + b*n2/w; w = (n1, n2)
         // v = (d2*w - d1) / (1 - w*w) * n1 - (d2 - d1*w) / (1 - w*w) * n2
         let w = self.normal.dot(other.normal);
-        let divisor = T::one() - w * w;
-        if divisor < T::approx_epsilon() * T::approx_epsilon() {
+        let divisor = 1.0 - w * w;
+        if divisor < f64::approx_epsilon() * f64::approx_epsilon() {
             return None;
         }
         let origin = Point3D::origin() + self.normal * ((other.offset * w - self.offset) / divisor)
@@ -227,23 +191,21 @@ impl<
 }
 
 /// Generic plane splitter interface
-pub trait Splitter<T, U, A> {
+pub trait Splitter<A> {
     /// Reset the splitter results.
     fn reset(&mut self);
 
     /// Add a new polygon and return a slice of the subdivisions
     /// that avoid collision with any of the previously added polygons.
-    fn add(&mut self, polygon: Polygon<T, U, A>);
+    fn add(&mut self, polygon: Polygon<A>);
 
     /// Sort the produced polygon set by the ascending distance across
     /// the specified view vector. Return the sorted slice.
-    fn sort(&mut self, view: Vector3D<T, U>) -> &[Polygon<T, U, A>];
+    fn sort(&mut self, view: Vector3D<f64>) -> &[Polygon<A>];
 
     /// Process a set of polygons at once.
-    fn solve(&mut self, input: &[Polygon<T, U, A>], view: Vector3D<T, U>) -> &[Polygon<T, U, A>]
+    fn solve(&mut self, input: &[Polygon<A>], view: Vector3D<f64>) -> &[Polygon<A>]
     where
-        T: Clone,
-        U: Clone,
         A: Copy,
     {
         self.reset();
@@ -257,45 +219,45 @@ pub trait Splitter<T, U, A> {
 /// Helper method used for benchmarks and tests.
 /// Constructs a 3D grid of polygons.
 #[doc(hidden)]
-pub fn make_grid(count: usize) -> Vec<Polygon<f32, (), usize>> {
-    let mut polys: Vec<Polygon<f32, (), usize>> = Vec::with_capacity(count * 3);
-    let len = count as f32;
+pub fn make_grid(count: usize) -> Vec<Polygon<usize>> {
+    let mut polys: Vec<Polygon<usize>> = Vec::with_capacity(count * 3);
+    let len = count as f64;
     polys.extend((0..count).map(|i| Polygon {
         points: [
-            Point3D::new(0.0, i as f32, 0.0),
-            Point3D::new(len, i as f32, 0.0),
-            Point3D::new(len, i as f32, len),
-            Point3D::new(0.0, i as f32, len),
+            Point3D::new(0.0, i as f64, 0.0),
+            Point3D::new(len, i as f64, 0.0),
+            Point3D::new(len, i as f64, len),
+            Point3D::new(0.0, i as f64, len),
         ],
         plane: Plane {
             normal: Vector3D::new(0.0, 1.0, 0.0),
-            offset: -(i as f32),
+            offset: -(i as f64),
         },
         anchor: 0,
     }));
     polys.extend((0..count).map(|i| Polygon {
         points: [
-            Point3D::new(i as f32, 0.0, 0.0),
-            Point3D::new(i as f32, len, 0.0),
-            Point3D::new(i as f32, len, len),
-            Point3D::new(i as f32, 0.0, len),
+            Point3D::new(i as f64, 0.0, 0.0),
+            Point3D::new(i as f64, len, 0.0),
+            Point3D::new(i as f64, len, len),
+            Point3D::new(i as f64, 0.0, len),
         ],
         plane: Plane {
             normal: Vector3D::new(1.0, 0.0, 0.0),
-            offset: -(i as f32),
+            offset: -(i as f64),
         },
         anchor: 0,
     }));
     polys.extend((0..count).map(|i| Polygon {
         points: [
-            Point3D::new(0.0, 0.0, i as f32),
-            Point3D::new(len, 0.0, i as f32),
-            Point3D::new(len, len, i as f32),
-            Point3D::new(0.0, len, i as f32),
+            Point3D::new(0.0, 0.0, i as f64),
+            Point3D::new(len, 0.0, i as f64),
+            Point3D::new(len, len, i as f64),
+            Point3D::new(0.0, len, i as f64),
         ],
         plane: Plane {
             normal: Vector3D::new(0.0, 0.0, 1.0),
-            offset: -(i as f32),
+            offset: -(i as f64),
         },
         anchor: 0,
     }));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,8 @@ mod bsp;
 mod clip;
 mod polygon;
 
+pub use bsp::{BspPlane, PlaneCut};
+
 use euclid::{approxeq::ApproxEq, Point3D, Scale, Vector3D};
 use num_traits::{Float, One, Zero};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ mod bsp;
 mod clip;
 mod polygon;
 
-pub use bsp::{BspPlane, PlaneCut};
+pub use bsp::PlaneCut;
 
 use euclid::{
     approxeq::ApproxEq,
@@ -187,32 +187,6 @@ impl Plane {
             origin,
             dir: cross_dir.normalize(),
         })
-    }
-}
-
-/// Generic plane splitter interface
-pub trait Splitter<A> {
-    /// Reset the splitter results.
-    fn reset(&mut self);
-
-    /// Add a new polygon and return a slice of the subdivisions
-    /// that avoid collision with any of the previously added polygons.
-    fn add(&mut self, polygon: Polygon<A>);
-
-    /// Sort the produced polygon set by the ascending distance across
-    /// the specified view vector. Return the sorted slice.
-    fn sort(&mut self, view: Vector3D<f64>) -> &[Polygon<A>];
-
-    /// Process a set of polygons at once.
-    fn solve(&mut self, input: &[Polygon<A>], view: Vector3D<f64>) -> &[Polygon<A>]
-    where
-        A: Copy,
-    {
-        self.reset();
-        for p in input {
-            self.add(p.clone());
-        }
-        self.sort(view)
     }
 }
 

--- a/src/polygon.rs
+++ b/src/polygon.rs
@@ -4,7 +4,6 @@ use euclid::{
     approxeq::ApproxEq,
     default::{Point2D, Point3D, Rect, Transform3D, Vector3D},
 };
-use num_traits::Float;
 
 use std::{iter, mem};
 
@@ -132,7 +131,7 @@ where
         let edge3 = points[3] - points[0];
         let edge4 = points[3] - points[1];
 
-        if edge2.square_length() < f64::epsilon() || edge4.square_length() < f64::epsilon() {
+        if edge2.square_length() < f64::EPSILON || edge4.square_length() < f64::EPSILON {
             return None;
         }
 
@@ -289,8 +288,8 @@ where
     /// Check if the polygon doesn't contain any space. This may happen
     /// after a sequence of splits, and such polygons should be discarded.
     pub fn is_empty(&self) -> bool {
-        (self.points[0] - self.points[2]).square_length() < f64::epsilon()
-            || (self.points[1] - self.points[3]).square_length() < f64::epsilon()
+        (self.points[0] - self.points[2]).square_length() < f64::EPSILON
+            || (self.points[1] - self.points[3]).square_length() < f64::EPSILON
     }
 
     /// Check if this polygon contains another one.

--- a/src/polygon.rs
+++ b/src/polygon.rs
@@ -1,22 +1,22 @@
 use crate::{is_zero, Line, Plane};
 
-use euclid::{approxeq::ApproxEq, default::Point2D, Point3D, Rect, Transform3D, Trig, Vector3D};
-use num_traits::{Float, One, Zero};
+use euclid::{
+    approxeq::ApproxEq,
+    default::{Point2D, Point3D, Rect, Transform3D, Vector3D},
+};
+use num_traits::Float;
 
-use std::{fmt, iter, mem, ops};
+use std::{iter, mem};
 
 /// The projection of a `Polygon` on a line.
-pub struct LineProjection<T> {
+pub struct LineProjection {
     /// Projected value of each point in the polygon.
-    pub markers: [T; 4],
+    pub markers: [f64; 4],
 }
 
-impl<T> LineProjection<T>
-where
-    T: Copy + PartialOrd + ops::Sub<T, Output = T> + ops::Add<T, Output = T>,
-{
+impl LineProjection {
     /// Get the min/max of the line projection markers.
-    pub fn get_bounds(&self) -> (T, T) {
+    pub fn get_bounds(&self) -> (f64, f64) {
         let (mut a, mut b, mut c, mut d) = (
             self.markers[0],
             self.markers[1],
@@ -95,17 +95,17 @@ impl<T> Intersection<T> {
 
 /// A convex polygon with 4 points lying on a plane.
 #[derive(Debug, PartialEq)]
-pub struct Polygon<T, U, A> {
+pub struct Polygon<A> {
     /// Points making the polygon.
-    pub points: [Point3D<T, U>; 4],
+    pub points: [Point3D<f64>; 4],
     /// A plane describing polygon orientation.
-    pub plane: Plane<T, U>,
+    pub plane: Plane,
     /// A simple anchoring index to allow association of the
     /// produced split polygons with the original one.
     pub anchor: A,
 }
 
-impl<T: Clone, U, A: Copy> Clone for Polygon<T, U, A> {
+impl<A: Copy> Clone for Polygon<A> {
     fn clone(&self) -> Self {
         Polygon {
             points: [
@@ -120,30 +120,19 @@ impl<T: Clone, U, A: Copy> Clone for Polygon<T, U, A> {
     }
 }
 
-impl<T, U, A> Polygon<T, U, A>
+impl<A> Polygon<A>
 where
-    T: Copy
-        + fmt::Debug
-        + ApproxEq<T>
-        + ops::Sub<T, Output = T>
-        + ops::Add<T, Output = T>
-        + ops::Mul<T, Output = T>
-        + ops::Div<T, Output = T>
-        + Zero
-        + One
-        + Float,
-    U: fmt::Debug,
     A: Copy,
 {
     /// Construct a polygon from points that are already transformed.
     /// Return None if the polygon doesn't contain any space.
-    pub fn from_points(points: [Point3D<T, U>; 4], anchor: A) -> Option<Self> {
+    pub fn from_points(points: [Point3D<f64>; 4], anchor: A) -> Option<Self> {
         let edge1 = points[1] - points[0];
         let edge2 = points[2] - points[0];
         let edge3 = points[3] - points[0];
         let edge4 = points[3] - points[1];
 
-        if edge2.square_length() < T::epsilon() || edge4.square_length() < T::epsilon() {
+        if edge2.square_length() < f64::epsilon() || edge4.square_length() < f64::epsilon() {
             return None;
         }
 
@@ -170,71 +159,62 @@ where
     }
 
     /// Construct a polygon from a non-transformed rectangle.
-    pub fn from_rect(rect: Rect<T, U>, anchor: A) -> Self {
+    pub fn from_rect(rect: Rect<f64>, anchor: A) -> Self {
         let min = rect.min();
         let max = rect.max();
-        let _0 = T::zero();
         Polygon {
             points: [
                 min.to_3d(),
-                Point3D::new(max.x, min.y, _0),
+                Point3D::new(max.x, min.y, 0.0),
                 max.to_3d(),
-                Point3D::new(min.x, max.y, _0),
+                Point3D::new(min.x, max.y, 0.0),
             ],
             plane: Plane {
-                normal: Vector3D::new(T::zero(), T::zero(), T::one()),
-                offset: T::zero(),
+                normal: Vector3D::new(0.0, 0.0, 1.0),
+                offset: 0.0,
             },
             anchor,
         }
     }
 
     /// Construct a polygon from a rectangle with 3D transform.
-    pub fn from_transformed_rect<V>(
-        rect: Rect<T, V>,
-        transform: Transform3D<T, V, U>,
+    pub fn from_transformed_rect(
+        rect: Rect<f64>,
+        transform: Transform3D<f64>,
         anchor: A,
-    ) -> Option<Self>
-    where
-        T: Trig + ops::Neg<Output = T>,
-    {
+    ) -> Option<Self> {
         let min = rect.min();
         let max = rect.max();
-        let _0 = T::zero();
         let points = [
             transform.transform_point3d(min.to_3d())?,
-            transform.transform_point3d(Point3D::new(max.x, min.y, _0))?,
+            transform.transform_point3d(Point3D::new(max.x, min.y, 0.0))?,
             transform.transform_point3d(max.to_3d())?,
-            transform.transform_point3d(Point3D::new(min.x, max.y, _0))?,
+            transform.transform_point3d(Point3D::new(min.x, max.y, 0.0))?,
         ];
         Self::from_points(points, anchor)
     }
 
     /// Construct a polygon from a rectangle with an invertible 3D transform.
-    pub fn from_transformed_rect_with_inverse<V>(
-        rect: Rect<T, V>,
-        transform: &Transform3D<T, V, U>,
-        inv_transform: &Transform3D<T, U, V>,
+    pub fn from_transformed_rect_with_inverse(
+        rect: Rect<f64>,
+        transform: &Transform3D<f64>,
+        inv_transform: &Transform3D<f64>,
         anchor: A,
-    ) -> Option<Self>
-    where
-        T: Trig + ops::Neg<Output = T>,
-    {
+    ) -> Option<Self> {
         let min = rect.min();
         let max = rect.max();
-        let _0 = T::zero();
         let points = [
             transform.transform_point3d(min.to_3d())?,
-            transform.transform_point3d(Point3D::new(max.x, min.y, _0))?,
+            transform.transform_point3d(Point3D::new(max.x, min.y, 0.0))?,
             transform.transform_point3d(max.to_3d())?,
-            transform.transform_point3d(Point3D::new(min.x, max.y, _0))?,
+            transform.transform_point3d(Point3D::new(min.x, max.y, 0.0))?,
         ];
 
         // Compute the normal directly from the transformation. This guarantees consistent polygons
         // generated from various local rectanges on the same geometry plane.
         let normal_raw = Vector3D::new(inv_transform.m13, inv_transform.m23, inv_transform.m33);
         let normal_sql = normal_raw.square_length();
-        if normal_sql.approx_eq(&T::zero()) || transform.m44.approx_eq(&T::zero()) {
+        if normal_sql.approx_eq(&0.0) || transform.m44.approx_eq(&0.0) {
             None
         } else {
             let normal = normal_raw / normal_sql.sqrt();
@@ -251,7 +231,7 @@ where
 
     /// Bring a point into the local coordinate space, returning
     /// the 2D normalized coordinates.
-    pub fn untransform_point(&self, point: Point3D<T, U>) -> Point2D<T> {
+    pub fn untransform_point(&self, point: Point3D<f64>) -> Point2D<f64> {
         //debug_assert!(self.contains(point));
         // get axises and target vector
         let a = self.points[1] - self.points[0];
@@ -271,20 +251,16 @@ where
     }
 
     /// Transform a polygon by an affine transform (preserving straight lines).
-    pub fn transform<V>(&self, transform: &Transform3D<T, U, V>) -> Option<Polygon<T, V, A>>
-    where
-        T: Trig,
-        V: fmt::Debug,
-    {
+    pub fn transform(&self, transform: &Transform3D<f64>) -> Option<Polygon<A>> {
         let mut points = [Point3D::origin(); 4];
         for (out, point) in points.iter_mut().zip(self.points.iter()) {
             let mut homo = transform.transform_point3d_homogeneous(*point);
-            homo.w = homo.w.max(T::approx_epsilon());
+            homo.w = homo.w.max(f64::approx_epsilon());
             *out = homo.to_point3d()?;
         }
 
         //Note: this code path could be more efficient if we had inverse-transpose
-        //let n4 = transform.transform_point4d(&Point4D::new(T::zero(), T::zero(), T::one(), T::zero()));
+        //let n4 = transform.transform_point4d(&Point4D::new(0.0, 0.0, T::one(), 0.0));
         //let normal = Point3D::new(n4.x, n4.y, n4.z);
         Polygon::from_points(points, self.anchor)
     }
@@ -306,15 +282,15 @@ where
         let is_winding = edges
             .iter()
             .zip(edges[1..].iter())
-            .all(|(a, &b)| a.cross(b).dot(anchor) >= T::zero());
+            .all(|(a, &b)| a.cross(b).dot(anchor) >= 0.0);
         is_planar && is_winding
     }
 
     /// Check if the polygon doesn't contain any space. This may happen
     /// after a sequence of splits, and such polygons should be discarded.
     pub fn is_empty(&self) -> bool {
-        (self.points[0] - self.points[2]).square_length() < T::epsilon()
-            || (self.points[1] - self.points[3]).square_length() < T::epsilon()
+        (self.points[0] - self.points[2]).square_length() < f64::epsilon()
+            || (self.points[1] - self.points[3]).square_length() < f64::epsilon()
     }
 
     /// Check if this polygon contains another one.
@@ -325,7 +301,7 @@ where
 
     /// Project this polygon onto a 3D vector, returning a line projection.
     /// Note: we can think of it as a projection to a ray placed at the origin.
-    pub fn project_on(&self, vector: &Vector3D<T, U>) -> LineProjection<T> {
+    pub fn project_on(&self, vector: &Vector3D<f64>) -> LineProjection {
         LineProjection {
             markers: [
                 vector.dot(self.points[0].to_vector()),
@@ -337,7 +313,7 @@ where
     }
 
     /// Compute the line of intersection with an infinite plane.
-    pub fn intersect_plane(&self, other: &Plane<T, U>) -> Intersection<Line<T, U>> {
+    pub fn intersect_plane(&self, other: &Plane) -> Intersection<Line> {
         if other.are_outside(&self.points) {
             log::debug!("\t\tOutside of the plane");
             return Intersection::Outside;
@@ -352,7 +328,7 @@ where
     }
 
     /// Compute the line of intersection with another polygon.
-    pub fn intersect(&self, other: &Self) -> Intersection<Line<T, U>> {
+    pub fn intersect(&self, other: &Self) -> Intersection<Line> {
         if self.plane.are_outside(&other.points) || other.plane.are_outside(&self.points) {
             log::debug!("\t\tOne is completely outside of the other");
             return Intersection::Outside;
@@ -378,8 +354,8 @@ where
 
     fn split_impl(
         &mut self,
-        first: (usize, Point3D<T, U>),
-        second: (usize, Point3D<T, U>),
+        first: (usize, Point3D<f64>),
+        second: (usize, Point3D<f64>),
     ) -> (Option<Self>, Option<Self>) {
         //TODO: can be optimized for when the polygon has a redundant 4th vertex
         //TODO: can be simplified greatly if only working with triangles
@@ -464,7 +440,7 @@ where
     /// Split the polygon along the specified `Line`.
     /// Will do nothing if the line doesn't belong to the polygon plane.
     #[deprecated(note = "Use split_with_normal instead")]
-    pub fn split(&mut self, line: &Line<T, U>) -> (Option<Self>, Option<Self>) {
+    pub fn split(&mut self, line: &Line) -> (Option<Self>, Option<Self>) {
         log::debug!("\tSplitting");
         // check if the cut is within the polygon plane first
         if !is_zero(self.plane.normal.dot(line.dir))
@@ -488,7 +464,7 @@ where
             .zip(cuts.iter_mut())
         {
             if let Some(t) = line.intersect_edge(a..b) {
-                if t >= T::zero() && t < T::one() {
+                if t >= 0.0 && t < 1.0 {
                     *cut = Some(a + (b - a) * t);
                 }
             }
@@ -514,12 +490,12 @@ where
     /// Will do nothing if the line doesn't belong to the polygon plane.
     pub fn split_with_normal(
         &mut self,
-        line: &Line<T, U>,
-        normal: &Vector3D<T, U>,
+        line: &Line,
+        normal: &Vector3D<f64>,
     ) -> (Option<Self>, Option<Self>) {
         log::debug!("\tSplitting with normal");
         // figure out which side of the split does each point belong to
-        let mut sides = [T::zero(); 4];
+        let mut sides = [0.0; 4];
         let (mut cut_positive, mut cut_negative) = (None, None);
         for (side, point) in sides.iter_mut().zip(&self.points) {
             *side = normal.dot(*point - line.origin);
@@ -533,9 +509,9 @@ where
             .enumerate()
         {
             // figure out if an edge between 0 and 1 needs to be cut
-            let cut = if side0 < T::zero() && side1 >= T::zero() {
+            let cut = if side0 < 0.0 && side1 >= 0.0 {
                 &mut cut_positive
-            } else if side0 > T::zero() && side1 <= T::zero() {
+            } else if side0 > 0.0 && side1 <= 0.0 {
                 &mut cut_negative
             } else {
                 continue;
@@ -575,7 +551,7 @@ where
 #[test]
 fn test_split_precision() {
     // regression test for https://bugzilla.mozilla.org/show_bug.cgi?id=1678454
-    let mut polygon = Polygon::<_, (), ()> {
+    let mut polygon = Polygon::<()> {
         points: [
             Point3D::new(300.0102, 150.00958, 0.0),
             Point3D::new(606.0, 306.0, 0.0),

--- a/src/polygon.rs
+++ b/src/polygon.rs
@@ -545,6 +545,88 @@ where
             (None, None)
         }
     }
+
+    pub fn cut(&self, mut poly: Self) -> PlaneCut<Self> {
+        //Note: we treat `self` as a plane, and `poly` as a concrete polygon here
+        let (intersection, dist) = match self.plane.intersect(&poly.plane) {
+            None => {
+                let ndot = self.plane.normal.dot(poly.plane.normal);
+                let dist = self.plane.offset - ndot * poly.plane.offset;
+                (Intersection::Coplanar, dist)
+            }
+            Some(_) if self.plane.are_outside(&poly.points[..]) => {
+                //Note: we can't start with `are_outside` because it's subject to FP precision
+                let dist = self.plane.signed_distance_sum_to(&poly);
+                (Intersection::Outside, dist)
+            }
+            Some(line) => {
+                //Note: distance isn't relevant here
+                (Intersection::Inside(line), 0.0)
+            }
+        };
+
+        match intersection {
+            //Note: we deliberately make the comparison wider than just with T::epsilon().
+            // This is done to avoid mistakenly ordering items that should be on the same
+            // plane but end up slightly different due to the floating point precision.
+            Intersection::Coplanar if is_zero(dist) => PlaneCut::Sibling(poly),
+            Intersection::Coplanar | Intersection::Outside => {
+                if dist > 0.0 {
+                    PlaneCut::Cut {
+                        front: vec![poly],
+                        back: vec![],
+                    }
+                } else {
+                    PlaneCut::Cut {
+                        front: vec![],
+                        back: vec![poly],
+                    }
+                }
+            }
+            Intersection::Inside(line) => {
+                let (res_add1, res_add2) = poly.split_with_normal(&line, &self.plane.normal);
+                let mut front = Vec::new();
+                let mut back = Vec::new();
+
+                for sub in iter::once(poly)
+                    .chain(res_add1)
+                    .chain(res_add2)
+                    .filter(|p| !p.is_empty())
+                {
+                    let dist = self.plane.signed_distance_sum_to(&sub);
+                    if dist > 0.0 {
+                        front.push(sub)
+                    } else {
+                        back.push(sub)
+                    }
+                }
+
+                PlaneCut::Cut { front, back }
+            }
+        }
+    }
+
+    pub fn is_aligned(&self, other: &Self) -> bool {
+        self.plane.normal.dot(other.plane.normal) > 0.0
+    }
+}
+
+/// The result of one plane being cut by another one.
+/// The "cut" here is an attempt to classify a plane as being
+/// in front or in the back of another one.
+#[derive(Debug)]
+pub enum PlaneCut<T> {
+    /// The planes are one the same geometrical plane.
+    Sibling(T),
+    /// Planes are different, thus we can either determine that
+    /// our plane is completely in front/back of another one,
+    /// or split it into these sub-groups.
+    Cut {
+        /// Sub-planes in front of the base plane.
+        front: Vec<T>,
+        /// Sub-planes in the back of the base plane.
+        back: Vec<T>,
+    },
 }
 
 #[test]

--- a/tests/clip.rs
+++ b/tests/clip.rs
@@ -1,11 +1,14 @@
-use euclid::{point3, rect, vec3, Angle, Rect, Transform3D};
+use euclid::{
+    default::{Rect, Transform3D},
+    point3, rect, vec3, Angle,
+};
 use plane_split::{Clipper, Plane, Polygon};
 
-use std::f32::consts::FRAC_PI_4;
+use std::f64::consts::FRAC_PI_4;
 
 #[test]
 fn clip_in() {
-    let plane: Plane<f32, ()> = Plane::from_unnormalized(vec3(1.0, 0.0, 1.0), 20.0)
+    let plane = Plane::from_unnormalized(vec3(1.0, 0.0, 1.0), 20.0)
         .unwrap()
         .unwrap();
     let mut clipper = Clipper::new();
@@ -29,7 +32,7 @@ fn clip_in() {
 
 #[test]
 fn clip_out() {
-    let plane: Plane<f32, ()> = Plane::from_unnormalized(vec3(1.0, 0.0, 1.0), -20.0)
+    let plane = Plane::from_unnormalized(vec3(1.0, 0.0, 1.0), -20.0)
         .unwrap()
         .unwrap();
     let mut clipper = Clipper::new();
@@ -52,7 +55,7 @@ fn clip_out() {
 
 #[test]
 fn clip_parallel() {
-    let plane: Plane<f32, ()> = Plane {
+    let plane = Plane {
         normal: vec3(0.0, 0.0, 1.0),
         offset: 0.0,
     };
@@ -76,7 +79,7 @@ fn clip_parallel() {
 
 #[test]
 fn clip_repeat() {
-    let plane: Plane<f32, ()> = Plane::from_unnormalized(vec3(1.0, 0.0, 1.0), 0.0)
+    let plane = Plane::from_unnormalized(vec3(1.0, 0.0, 1.0), 0.0)
         .unwrap()
         .unwrap();
     let mut clipper = Clipper::new();
@@ -101,13 +104,12 @@ fn clip_repeat() {
 
 #[test]
 fn clip_transformed() {
-    let t_rot: Transform3D<f32, (), ()> =
-        Transform3D::rotation(0.0, 1.0, 0.0, Angle::radians(-FRAC_PI_4));
-    let t_div: Transform3D<f32, (), ()> = Transform3D::perspective(5.0);
+    let t_rot: Transform3D<f64> = Transform3D::rotation(0.0, 1.0, 0.0, Angle::radians(-FRAC_PI_4));
+    let t_div: Transform3D<f64> = Transform3D::perspective(5.0);
     let transform = t_rot.then(&t_div);
 
     let polygon = Polygon::from_rect(rect(-10.0, -10.0, 20.0, 20.0), 0);
-    let bounds: Rect<f32, ()> = rect(-1.0, -1.0, 2.0, 2.0);
+    let bounds: Rect<f64> = rect(-1.0, -1.0, 2.0, 2.0);
 
     let mut clipper = Clipper::new();
     let results = clipper.clip_transformed(polygon, &transform, Some(bounds));
@@ -117,7 +119,7 @@ fn clip_transformed() {
 
 #[test]
 fn clip_badly_transformed() {
-    let mut tx = Transform3D::<f32, (), ()>::identity();
+    let mut tx = Transform3D::<f64>::identity();
     tx.m14 = -0.0000001;
     tx.m44 = 0.0;
 
@@ -129,7 +131,7 @@ fn clip_badly_transformed() {
 
 #[test]
 fn clip_near_coplanar() {
-    let tx = Transform3D::<f32, (), ()>::new(
+    let tx = Transform3D::<f64>::new(
         1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, -960.0, -625.0, 1.0, -1.0, 100.0, -2852.0, 0.0, 1.0,
     );
     let mut clipper = Clipper::new();

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -1,19 +1,23 @@
-use euclid::{approxeq::ApproxEq, point2, point3, vec3, Angle, Rect, Size2D, Transform3D};
+use euclid::{
+    approxeq::ApproxEq,
+    default::{Rect, Size2D, Transform3D},
+    point2, point3, vec3, Angle,
+};
 use plane_split::{Intersection, Line, LineProjection, NegativeHemisphereError, Plane, Polygon};
 
 #[test]
 fn line_proj_bounds() {
     assert_eq!(
-        (-5i8, 4),
+        (-5.0f64, 4.0),
         LineProjection {
-            markers: [-5i8, 1, 4, 2]
+            markers: [-5.0f64, 1.0, 4.0, 2.0]
         }
         .get_bounds()
     );
     assert_eq!(
-        (1f32, 4.0),
+        (1f64, 4.0),
         LineProjection {
-            markers: [4f32, 3.0, 2.0, 1.0]
+            markers: [4f64, 3.0, 2.0, 1.0]
         }
         .get_bounds()
     );
@@ -21,7 +25,7 @@ fn line_proj_bounds() {
 
 #[test]
 fn valid() {
-    let poly_a: Polygon<f32, (), usize> = Polygon {
+    let poly_a: Polygon<usize> = Polygon {
         points: [
             point3(0.0, 0.0, 0.0),
             point3(1.0, 1.0, 1.0),
@@ -35,7 +39,7 @@ fn valid() {
         anchor: 0,
     };
     assert!(!poly_a.is_valid()); // points[0] is outside
-    let poly_b: Polygon<f32, (), usize> = Polygon {
+    let poly_b: Polygon<usize> = Polygon {
         points: [
             point3(0.0, 1.0, 0.0),
             point3(1.0, 1.0, 1.0),
@@ -49,7 +53,7 @@ fn valid() {
         anchor: 0,
     };
     assert!(!poly_b.is_valid()); // winding is incorrect
-    let poly_c: Polygon<f32, (), usize> = Polygon {
+    let poly_c: Polygon<usize> = Polygon {
         points: [
             point3(0.0, 0.0, 1.0),
             point3(1.0, 0.0, 1.0),
@@ -67,19 +71,19 @@ fn valid() {
 
 #[test]
 fn empty() {
-    let poly = Polygon::<f32, (), usize>::from_points(
+    let poly = Polygon::from_points(
         [
             point3(0.0, 0.0, 1.0),
             point3(0.0, 0.0, 1.0),
-            point3(0.0, 0.00001, 1.0),
+            point3(0.0, 0.00000001, 1.0),
             point3(1.0, 0.0, 0.0),
         ],
-        1,
+        1usize,
     );
     assert_eq!(None, poly);
 }
 
-fn test_transformed(rect: Rect<f32, ()>, transform: Transform3D<f32, (), ()>) {
+fn test_transformed(rect: Rect<f64>, transform: Transform3D<f64>) {
     let poly = Polygon::from_transformed_rect(rect, transform, 0).unwrap();
     assert!(poly.is_valid());
 
@@ -94,7 +98,7 @@ fn test_transformed(rect: Rect<f32, ()>, transform: Transform3D<f32, (), ()>) {
 #[test]
 fn from_transformed_rect() {
     let rect = Rect::new(point2(10.0, 10.0), Size2D::new(20.0, 30.0));
-    let transform = Transform3D::rotation(0.5f32.sqrt(), 0.0, 0.5f32.sqrt(), Angle::radians(5.0))
+    let transform = Transform3D::rotation(0.5f64.sqrt(), 0.0, 0.5f64.sqrt(), Angle::radians(5.0))
         .pre_translate(vec3(0.0, 0.0, 10.0));
     test_transformed(rect, transform);
 }
@@ -109,7 +113,7 @@ fn from_transformed_rect_perspective() {
 
 #[test]
 fn untransform_point() {
-    let poly: Polygon<f32, (), usize> = Polygon {
+    let poly: Polygon<usize> = Polygon {
         points: [
             point3(0.0, 0.0, 0.0),
             point3(0.5, 1.0, 0.0),
@@ -130,7 +134,7 @@ fn untransform_point() {
 
 #[test]
 fn are_outside() {
-    let plane: Plane<f32, ()> = Plane {
+    let plane = Plane {
         normal: vec3(0.0, 0.0, 1.0),
         offset: -1.0,
     };
@@ -141,7 +145,7 @@ fn are_outside() {
 
 #[test]
 fn intersect() {
-    let poly_a: Polygon<f32, (), usize> = Polygon {
+    let poly_a: Polygon<usize> = Polygon {
         points: [
             point3(0.0, 0.0, 1.0),
             point3(1.0, 0.0, 1.0),
@@ -155,7 +159,7 @@ fn intersect() {
         anchor: 0,
     };
     assert!(poly_a.is_valid());
-    let poly_b: Polygon<f32, (), usize> = Polygon {
+    let poly_b: Polygon<usize> = Polygon {
         points: [
             point3(0.5, 0.0, 2.0),
             point3(0.5, 1.0, 2.0),
@@ -188,7 +192,7 @@ fn intersect() {
     assert!(poly_a.plane.normal.dot(intersection.dir).approx_eq(&0.0));
     assert!(poly_b.plane.normal.dot(intersection.dir).approx_eq(&0.0));
 
-    let poly_c: Polygon<f32, (), usize> = Polygon {
+    let poly_c: Polygon<usize> = Polygon {
         points: [
             point3(0.0, -1.0, 2.0),
             point3(0.0, -1.0, 0.0),
@@ -202,7 +206,7 @@ fn intersect() {
         anchor: 0,
     };
     assert!(poly_c.is_valid());
-    let poly_d: Polygon<f32, (), usize> = Polygon {
+    let poly_d: Polygon<usize> = Polygon {
         points: [
             point3(0.0, 0.0, 0.5),
             point3(1.0, 0.0, 0.5),
@@ -221,7 +225,7 @@ fn intersect() {
     assert!(poly_a.intersect(&poly_d).is_outside());
 }
 
-fn test_cut(poly_base: &Polygon<f32, (), usize>, extra_count: u8, line: Line<f32, ()>) {
+fn test_cut(poly_base: &Polygon<usize>, extra_count: u8, line: Line) {
     assert!(line.is_valid());
 
     let normal = poly_base.plane.normal.cross(line.dir).normalize();
@@ -240,7 +244,7 @@ fn test_cut(poly_base: &Polygon<f32, (), usize>, extra_count: u8, line: Line<f32
 
 #[test]
 fn split() {
-    let poly: Polygon<f32, (), usize> = Polygon {
+    let poly: Polygon<usize> = Polygon {
         points: [
             point3(0.0, 1.0, 0.0),
             point3(1.0, 1.0, 0.0),
@@ -280,7 +284,7 @@ fn split() {
         2,
         Line {
             origin: point3(0.0, 1.0, 0.5),
-            dir: vec3(0.5f32.sqrt(), 0.0, -0.5f32.sqrt()),
+            dir: vec3(0.5f64.sqrt(), 0.0, -0.5f64.sqrt()),
         },
     );
 
@@ -290,7 +294,7 @@ fn split() {
         2,
         Line {
             origin: point3(0.5, 1.0, 0.0),
-            dir: vec3(0.5f32.sqrt(), 0.0, 0.5f32.sqrt()),
+            dir: vec3(0.5f64.sqrt(), 0.0, 0.5f64.sqrt()),
         },
     );
 
@@ -300,7 +304,7 @@ fn split() {
         2,
         Line {
             origin: point3(0.5, 1.0, 0.0),
-            dir: vec3(-0.5f32.sqrt(), 0.0, 0.5f32.sqrt()),
+            dir: vec3(-0.5f64.sqrt(), 0.0, 0.5f64.sqrt()),
         },
     );
 
@@ -310,7 +314,7 @@ fn split() {
         1,
         Line {
             origin: point3(0.0, 1.0, 0.0),
-            dir: vec3(0.5f32.sqrt(), 0.0, 0.5f32.sqrt()),
+            dir: vec3(0.5f64.sqrt(), 0.0, 0.5f64.sqrt()),
         },
     );
 }
@@ -318,19 +322,20 @@ fn split() {
 #[test]
 fn plane_unnormalized() {
     let zero_vec = vec3(0.0000001, 0.0, 0.0);
-    let mut plane: Result<Option<Plane<f32, ()>>, _> = Plane::from_unnormalized(zero_vec, 1.0);
+    let mut plane: Result<Option<Plane>, _> = Plane::from_unnormalized(zero_vec, 1.0);
     assert_eq!(plane, Ok(None));
     plane = Plane::from_unnormalized(zero_vec, 0.0);
     assert_eq!(plane, Err(NegativeHemisphereError));
     plane = Plane::from_unnormalized(zero_vec, -0.5);
     assert_eq!(plane, Err(NegativeHemisphereError));
 
-    plane = Plane::from_unnormalized(vec3(-3.0, 4.0, 0.0), 2.0);
-    assert_eq!(
-        plane,
-        Ok(Some(Plane {
-            normal: vec3(-3.0 / 5.0, 4.0 / 5.0, 0.0),
-            offset: 2.0 / 5.0,
-        }))
-    );
+    let plane = Plane::from_unnormalized(vec3(-3.0, 4.0, 0.0), 2.0)
+        .unwrap()
+        .unwrap();
+    let expected = Plane {
+        normal: vec3(-3.0 / 5.0, 4.0 / 5.0, 0.0),
+        offset: 2.0 / 5.0,
+    };
+    assert!(plane.normal.approx_eq(&expected.normal));
+    assert!(plane.offset.approx_eq(&expected.offset));
 }

--- a/tests/split.rs
+++ b/tests/split.rs
@@ -1,6 +1,6 @@
-use binary_space_partition::{Plane as Plane_, PlaneCut};
 use euclid::{rect, vec3, Angle, Rect, Transform3D};
 use plane_split::{make_grid, BspSplitter, Polygon, Splitter};
+use plane_split::{BspPlane, PlaneCut};
 use std::f32::consts::FRAC_PI_4;
 
 fn grid_impl(count: usize, splitter: &mut dyn Splitter<f32, (), usize>) {

--- a/tests/split.rs
+++ b/tests/split.rs
@@ -2,10 +2,11 @@ use euclid::{
     default::{Rect, Transform3D},
     rect, vec3, Angle,
 };
-use plane_split::{make_grid, BspSplitter, Polygon, Splitter};
+use plane_split::PlaneCut;
+use plane_split::{make_grid, BspSplitter, Polygon};
 use std::f64::consts::FRAC_PI_4;
 
-fn grid_impl(count: usize, splitter: &mut dyn Splitter<usize>) {
+fn grid_impl(count: usize, splitter: &mut BspSplitter<usize>) {
     let polys = make_grid(count);
     let result = splitter.solve(&polys, vec3(0.0, 0.0, 1.0));
     assert_eq!(result.len(), count + count * count + count * count * count);
@@ -16,7 +17,7 @@ fn grid_bsp() {
     grid_impl(2, &mut BspSplitter::new());
 }
 
-fn sort_rotation(splitter: &mut dyn Splitter<usize>) {
+fn sort_rotation(splitter: &mut BspSplitter<usize>) {
     let transform0: Transform3D<f64> =
         Transform3D::rotation(0.0, 1.0, 0.0, Angle::radians(-FRAC_PI_4));
     let transform1: Transform3D<f64> = Transform3D::rotation(0.0, 1.0, 0.0, Angle::radians(0.0));
@@ -43,7 +44,7 @@ fn rotation_bsp() {
     sort_rotation(&mut BspSplitter::new());
 }
 
-fn sort_trivial(splitter: &mut dyn Splitter<usize>) {
+fn sort_trivial(splitter: &mut BspSplitter<usize>) {
     let anchors: Vec<_> = (0usize..10).collect();
     let rect: Rect<f64> = rect(-10.0, -10.0, 20.0, 20.0);
     let polys: Vec<_> = anchors
@@ -64,7 +65,7 @@ fn sort_trivial(splitter: &mut dyn Splitter<usize>) {
     assert_eq!(anchors1, anchors2);
 }
 
-fn sort_external(splitter: &mut dyn Splitter<usize>) {
+fn sort_external(splitter: &mut BspSplitter<usize>) {
     let rect0: Rect<f64> = rect(-10.0, -10.0, 20.0, 20.0);
     let poly0 = Polygon::from_rect(rect0, 0);
     let poly1 = {

--- a/tests/split.rs
+++ b/tests/split.rs
@@ -1,9 +1,11 @@
-use euclid::{rect, vec3, Angle, Rect, Transform3D};
+use euclid::{
+    default::{Rect, Transform3D},
+    rect, vec3, Angle,
+};
 use plane_split::{make_grid, BspSplitter, Polygon, Splitter};
-use plane_split::{BspPlane, PlaneCut};
-use std::f32::consts::FRAC_PI_4;
+use std::f64::consts::FRAC_PI_4;
 
-fn grid_impl(count: usize, splitter: &mut dyn Splitter<f32, (), usize>) {
+fn grid_impl(count: usize, splitter: &mut dyn Splitter<usize>) {
     let polys = make_grid(count);
     let result = splitter.solve(&polys, vec3(0.0, 0.0, 1.0));
     assert_eq!(result.len(), count + count * count + count * count * count);
@@ -14,15 +16,14 @@ fn grid_bsp() {
     grid_impl(2, &mut BspSplitter::new());
 }
 
-fn sort_rotation(splitter: &mut dyn Splitter<f32, (), usize>) {
-    let transform0: Transform3D<f32, (), ()> =
+fn sort_rotation(splitter: &mut dyn Splitter<usize>) {
+    let transform0: Transform3D<f64> =
         Transform3D::rotation(0.0, 1.0, 0.0, Angle::radians(-FRAC_PI_4));
-    let transform1: Transform3D<f32, (), ()> =
-        Transform3D::rotation(0.0, 1.0, 0.0, Angle::radians(0.0));
-    let transform2: Transform3D<f32, (), ()> =
+    let transform1: Transform3D<f64> = Transform3D::rotation(0.0, 1.0, 0.0, Angle::radians(0.0));
+    let transform2: Transform3D<f64> =
         Transform3D::rotation(0.0, 1.0, 0.0, Angle::radians(FRAC_PI_4));
 
-    let rect: Rect<f32, ()> = rect(-10.0, -10.0, 20.0, 20.0);
+    let rect: Rect<f64> = rect(-10.0, -10.0, 20.0, 20.0);
     let p1 = Polygon::from_transformed_rect(rect, transform0, 0);
     let p2 = Polygon::from_transformed_rect(rect, transform1, 1);
     let p3 = Polygon::from_transformed_rect(rect, transform2, 2);
@@ -42,14 +43,13 @@ fn rotation_bsp() {
     sort_rotation(&mut BspSplitter::new());
 }
 
-fn sort_trivial(splitter: &mut dyn Splitter<f32, (), usize>) {
+fn sort_trivial(splitter: &mut dyn Splitter<usize>) {
     let anchors: Vec<_> = (0usize..10).collect();
-    let rect: Rect<f32, ()> = rect(-10.0, -10.0, 20.0, 20.0);
+    let rect: Rect<f64> = rect(-10.0, -10.0, 20.0, 20.0);
     let polys: Vec<_> = anchors
         .iter()
         .map(|&anchor| {
-            let transform: Transform3D<f32, (), ()> =
-                Transform3D::translation(0.0, 0.0, anchor as f32);
+            let transform: Transform3D<f64> = Transform3D::translation(0.0, 0.0, anchor as f64);
             let poly = Polygon::from_transformed_rect(rect, transform, anchor);
             assert!(poly.is_some(), "Cannot construct transformed polygons");
             poly.unwrap()
@@ -64,13 +64,13 @@ fn sort_trivial(splitter: &mut dyn Splitter<f32, (), usize>) {
     assert_eq!(anchors1, anchors2);
 }
 
-fn sort_external(splitter: &mut dyn Splitter<f32, (), usize>) {
-    let rect0: Rect<f32, ()> = rect(-10.0, -10.0, 20.0, 20.0);
+fn sort_external(splitter: &mut dyn Splitter<usize>) {
+    let rect0: Rect<f64> = rect(-10.0, -10.0, 20.0, 20.0);
     let poly0 = Polygon::from_rect(rect0, 0);
     let poly1 = {
-        let transform0: Transform3D<f32, (), ()> =
+        let transform0: Transform3D<f64> =
             Transform3D::rotation(1.0, 0.0, 0.0, Angle::radians(2.0 * FRAC_PI_4));
-        let transform1: Transform3D<f32, (), ()> = Transform3D::translation(0.0, 100.0, 0.0);
+        let transform1: Transform3D<f64> = Transform3D::translation(0.0, 100.0, 0.0);
         Polygon::from_transformed_rect(rect0, transform0.then(&transform1), 1).unwrap()
     };
 
@@ -93,7 +93,7 @@ fn external_bsp() {
 
 #[test]
 fn test_cut() {
-    let rect: Rect<f32, ()> = rect(-10.0, -10.0, 20.0, 20.0);
+    let rect: Rect<f64> = rect(-10.0, -10.0, 20.0, 20.0);
     let poly = Polygon::from_rect(rect, 0);
     let mut poly2 = Polygon::from_rect(rect, 0);
     // test robustness for positions


### PR DESCRIPTION
This is a large PR, however each commit can be reviewed independently.

## Cleanups

The first few commits pretty drastically simplify the crate by:

 - Merging the `binary_space_partition` crate into `plane_split`. The separation was making it hard to improve the data structure because the abstraction was awkwardly sitting in the middle of it. `binary_space_partition` was only used with `plane_split`.
 - Remove a lot of generics. `plane_split` was making an effort to play nice with euclid's tagged units, however I think it wasn't worth the effort. This crate has few entry points so it's easy for users (pretty much only webrender) to convert to and from the unknown unit tag when interacting with this crate without causing invasive changes. Similarly, the whole crate was generic over the scalar type, but the crate's single user only uses it with f64. Removing this generic parameter also made for a very nice simplification.
 - Remove some useless traits with a single implementation. They were probably mostly there to accommodate the `plane_split`/`binary_space_partition` separation.

All of these are completely mechanical and should be straightforward to review.

## BSP tree rewrite

And then the final commit, which rewrites the BSP tree to make it a lot faster.

The previous version of the BSP tree used a very naive data structure where each node is boxed and contains vectors of boxed children.
As a result any slightly complex tree results in large amounts of small memory allocations that can't be reused and very slow performance overall.

The new plane BSP tree does not change the logic, only how nodes polygons are stored using the classic vector with indices storage approach.

Some profiling of problematic test cases in Firefox showed that the BSP trees tend to be deep with usually few children per node. This commit takes advantage of that, using SmallVec in a few places.
In addition, profiling showed that cloning and moving the Polygon struct was occupying a significant portion if the profile, so polygons are now passed by reference in the hottest parts of the code.

This commit makes the plane splitting around 3 times faster on test cases such as the ones in https://bugzilla.mozilla.org/show_bug.cgi?id=1768984 and https://bugzilla.mozilla.org/show_bug.cgi?id=1493359.
